### PR TITLE
feat/sisyfos-api: implemented fadeToBlack - fade out of all channels

### DIFF
--- a/src/devices/sisyfos.ts
+++ b/src/devices/sisyfos.ts
@@ -194,6 +194,11 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> {
 				if (layer.content.faderLevel !== undefined) {
 					deviceState.channels[foundMapping.channel].faderLevel = layer.content.faderLevel
 				}
+
+				if (layer.content.fadeToBlack !== undefined) {
+					deviceState.channels[foundMapping.channel].fadeToBlack = layer.content.fadeToBlack
+				}
+
 				deviceState.channels[foundMapping.channel].tlObjIds.push(tlObject.id)
 			}
 		})
@@ -263,6 +268,18 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> {
 						type: Commands.SET_FADER,
 						channel: Number(index),
 						value: newChannel.faderLevel
+					},
+					timelineObjId: newChannel.tlObjIds[0] || ''
+				})
+			}
+
+			if (oldChannel && oldChannel.fadeToBlack !== newChannel.fadeToBlack) {
+				commands.push({
+					context: 'fade all pgm to black',
+					content: {
+						type: Commands.FADE_TO_BLACK,
+						channel: 0,
+						value: newChannel.fadeToBlack
 					},
 					timelineObjId: newChannel.tlObjIds[0] || ''
 				})

--- a/src/devices/sisyfosAPI.ts
+++ b/src/devices/sisyfosAPI.ts
@@ -3,8 +3,7 @@ import {
 	SisyfosState,
 	SisyfosCommand,
 	Commands,
-	ToggleCommand,
-	FaderCommand,
+	ValueCommand,
 	SisyfosAPIState
 } from '../types/src/sisyfos'
 import { EventEmitter } from 'events'
@@ -75,22 +74,24 @@ export class SisyfosInterface extends EventEmitter {
 	send (command: SisyfosCommand) {
 		if (command.type === Commands.TAKE) {
 			this._oscClient.send({ address: '/take', args: [] })
+		} else if (command.type === Commands.FADE_TO_BLACK) {
+			this._oscClient.send({ address: '/fadetoblack', args: [] })
 		} else if (command.type === Commands.CLEAR_PST_ROW) {
 			this._oscClient.send({ address: '/clearpst', args: [] })
 		} else if (command.type === Commands.TOGGLE_PGM) {
-			this._oscClient.send({ address: `/ch/${(command as ToggleCommand).channel + 1}/pgm`, args: [{
+			this._oscClient.send({ address: `/ch/${(command as ValueCommand).channel + 1}/pgm`, args: [{
 				type: 'i',
-				value: (command as ToggleCommand).value
+				value: (command as ValueCommand).value
 			}] })
 		} else if (command.type === Commands.TOGGLE_PST) {
-			this._oscClient.send({ address: `/ch/${(command as ToggleCommand).channel + 1}/pst`, args: [{
+			this._oscClient.send({ address: `/ch/${(command as ValueCommand).channel + 1}/pst`, args: [{
 				type: 'i',
-				value: (command as ToggleCommand).value
+				value: (command as ValueCommand).value
 			}] })
 		} else if (command.type === Commands.SET_FADER) {
-			this._oscClient.send({ address: `/ch/${(command as FaderCommand).channel + 1}/faderlevel`, args: [{
+			this._oscClient.send({ address: `/ch/${(command as ValueCommand).channel + 1}/faderlevel`, args: [{
 				type: 'f',
-				value: (command as FaderCommand).value
+				value: (command as ValueCommand).value
 			}] })
 		}
 	}

--- a/src/types/src/sisyfos.ts
+++ b/src/types/src/sisyfos.ts
@@ -19,6 +19,7 @@ export interface SisyfosCommandContent {
 	type: TimelineContentTypeSisyfos.SISYFOS
 	isPgm?: number // 0=off 1=PGM 2=VO
 	faderLevel?: number
+	fadeToBlack?: boolean
 }
 export type TimelineObjSisyfosAny = TimelineObjSisyfosMessage
 
@@ -26,6 +27,7 @@ export enum Commands {
 	TOGGLE_PGM = 'togglePgm',
 	TOGGLE_PST = 'togglePst',
 	SET_FADER = 'setFader',
+	FADE_TO_BLACK = 'fadeToBlack',
 	CLEAR_PST_ROW = 'clearPstRow',
 	TAKE = 'take'
 }
@@ -35,22 +37,21 @@ export interface BaseCommand {
 }
 
 export interface ChannelCommand {
-	type: Commands.SET_FADER | Commands.TOGGLE_PGM | Commands.TOGGLE_PST
+	type: Commands.SET_FADER | Commands.TOGGLE_PGM | Commands.TOGGLE_PST | Commands.FADE_TO_BLACK
 	channel: number
 	value: boolean | number
 }
 
-export interface ToggleCommand extends ChannelCommand {
-	type: Commands.TOGGLE_PGM | Commands.TOGGLE_PST
+export interface BoolCommand extends ChannelCommand {
+	type: Commands.FADE_TO_BLACK
+	value: boolean
+}
+export interface ValueCommand extends ChannelCommand {
+	type: Commands.TOGGLE_PGM | Commands.TOGGLE_PST | Commands.SET_FADER
 	value: number
 }
 
-export interface FaderCommand extends ChannelCommand {
-	type: Commands.SET_FADER
-	value: number
-}
-
-export type SisyfosCommand = BaseCommand | ToggleCommand | FaderCommand
+export type SisyfosCommand = BaseCommand | ValueCommand | BoolCommand
 
 export interface SisyfosChannel extends SisyfosAPIChannel {
 	tlObjIds: string[]
@@ -77,6 +78,7 @@ export interface SisyfosAPIChannel {
 	faderLevel: number
 	pgmOn: number
 	pstOn: number
+	fadeToBlack: boolean
 }
 
 export interface SisyfosAPIState {


### PR DESCRIPTION
Implemented support for fadeToBlack:
(fading down all active channels)

```
content: {
			deviceType: DeviceType.SISYFOS,
			type: TimelineContentTypeSisyfos.SISYFOS,
			fadeToBlack: true
		},
``` 

Changed interfaces from function (ToggleCommand, FaderCommand) to type (BoolCommand, ValueCommand)
