### PR TITLE
Feat/sisyfos hide fader

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,19 @@ Activate channel 3 on sisyfos pgm output
 		label: 'SERVER B'
 	}
 }
+//VISIBLE: (shows or hide a fader)
+{
+	id: 'channel3',
+	enable: {
+		start: 'now'	
+	},
+	layer: 'myLayerSisyfosScene1',
+	content: {
+		deviceType: DeviceType.SISYFOS,
+		type: TimelineContentTypeSisyfos.SISYFOS,
+		visible: false // false: hide - true: show
+	}
+}
 //FADE TO BLACK: (fade out all channels)
 {
 	id: 'channel3',

--- a/src/devices/__tests__/sisyfos.spec.ts
+++ b/src/devices/__tests__/sisyfos.spec.ts
@@ -159,7 +159,7 @@ describe('Sisyfos', () => {
 			{
 				id: 'obj5',
 				enable: {
-					start: mockTime.now + 5000, // 4.1 seconds in the future
+					start: mockTime.now + 5000, // 5 seconds in the future
 					duration: 2000
 				},
 				layer: 'sisyfos_channel_1',
@@ -168,6 +168,32 @@ describe('Sisyfos', () => {
 					type: TimelineContentTypeSisyfos.SISYFOS,
 
 					label: 'MY TIME'
+				}
+			},
+			{
+				id: 'obj6',
+				enable: {
+					start: mockTime.now + 6000, // 6 seconds in the future
+					duration: 900
+				},
+				layer: 'sisyfos_channel_1',
+				content: {
+					deviceType: DeviceType.SISYFOS,
+					type: TimelineContentTypeSisyfos.SISYFOS,
+					visible: false
+				}
+			},
+			{
+				id: 'obj7',
+				enable: {
+					start: mockTime.now + 7000, // 7 seconds in the future
+					duration: 900
+				},
+				layer: 'sisyfos_channel_1',
+				content: {
+					deviceType: DeviceType.SISYFOS,
+					type: TimelineContentTypeSisyfos.SISYFOS,
+					visible: true
 				}
 			}
 		]
@@ -200,7 +226,7 @@ describe('Sisyfos', () => {
 		})
 
 		await mockTime.advanceTimeTicks(3000) // 6 seconds into the future
-		expect(commandReceiver0.mock.calls.length).toEqual(10)
+		expect(commandReceiver0.mock.calls.length).toEqual(11)
 		// set pst off
 		expect(getMockCall(commandReceiver0, 4, 1)).toMatchObject({
 			type: 'togglePst',
@@ -224,6 +250,12 @@ describe('Sisyfos', () => {
 			type: 'label',
 			channel: 0,
 			value: 'MY TIME'
+		})
+		// set visible false
+		expect(getMockCall(commandReceiver0, 10, 1)).toMatchObject({
+			type: 'visible',
+			channel: 0,
+			value: false
 		})
 	})
 

--- a/src/devices/sisyfos.ts
+++ b/src/devices/sisyfos.ts
@@ -163,6 +163,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 				pgmOn: 0,
 				pstOn: 0,
 				label: '',
+				visible: true,
 				tlObjIds: []
 			}
 
@@ -299,6 +300,18 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 						type: Commands.LABEL,
 						channel: Number(index),
 						value: newChannel.label
+					},
+					timelineObjId: newChannel.tlObjIds[0] || ''
+				})
+			}
+
+			if (oldChannel && oldChannel.visible !== newChannel.visible) {
+				commands.push({
+					context: `Channel ${index} Visibility goes from "${oldChannel.visible}" to "${newChannel.visible}"`,
+					content: {
+						type: Commands.VISIBLE,
+						channel: Number(index),
+						value: newChannel.visible
 					},
 					timelineObjId: newChannel.tlObjIds[0] || ''
 				})

--- a/src/devices/sisyfos.ts
+++ b/src/devices/sisyfos.ts
@@ -207,6 +207,10 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 					deviceState.channels[foundMapping.channel].label = layer.content.label
 				}
 
+				if (layer.content.visible !== undefined) {
+					deviceState.channels[foundMapping.channel].visible = layer.content.visible
+				}
+
 				deviceState.channels[foundMapping.channel].tlObjIds.push(tlObject.id)
 			}
 		})

--- a/src/devices/sisyfosAPI.ts
+++ b/src/devices/sisyfosAPI.ts
@@ -99,6 +99,11 @@ export class SisyfosInterface extends EventEmitter {
 				type: 'f',
 				value: (command as ValueCommand).value
 			}] })
+		} else if (command.type === Commands.VISIBLE) {
+			this._oscClient.send({ address: `/ch/${(command as ValueCommand).channel + 1}/visible`, args: [{
+				type: 'i',
+				value: (command as ValueCommand).value
+			}] })
 		}
 	}
 

--- a/src/types/src/sisyfos.ts
+++ b/src/types/src/sisyfos.ts
@@ -31,7 +31,8 @@ export enum Commands {
 	FADE_TO_BLACK = 'fadeToBlack',
 	CLEAR_PST_ROW = 'clearPstRow',
 	LABEL = 'label',
-	TAKE = 'take'
+	TAKE = 'take',
+	VISIBLE = 'visible'
 }
 
 export interface BaseCommand {
@@ -39,13 +40,13 @@ export interface BaseCommand {
 }
 
 export interface ChannelCommand {
-	type: Commands.SET_FADER | Commands.TOGGLE_PGM | Commands.TOGGLE_PST | Commands.FADE_TO_BLACK | Commands.LABEL
+	type: Commands.SET_FADER | Commands.TOGGLE_PGM | Commands.TOGGLE_PST | Commands.FADE_TO_BLACK | Commands.LABEL | Commands.VISIBLE
 	channel: number
 	value: boolean | number | string
 }
 
 export interface BoolCommand extends ChannelCommand {
-	type: Commands.FADE_TO_BLACK
+	type: Commands.FADE_TO_BLACK | Commands.VISIBLE
 	value: boolean
 }
 export interface ValueCommand extends ChannelCommand {
@@ -87,6 +88,7 @@ export interface SisyfosAPIChannel {
 	pstOn: number
 	fadeToBlack: boolean
 	label: string
+	visible: boolean
 }
 
 export interface SisyfosAPIState {

--- a/src/types/src/sisyfos.ts
+++ b/src/types/src/sisyfos.ts
@@ -21,6 +21,7 @@ export interface SisyfosCommandContent {
 	faderLevel?: number
 	fadeToBlack?: boolean
 	label?: string
+	visible?: boolean
 }
 export type TimelineObjSisyfosAny = TimelineObjSisyfosMessage
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Added visible: true/false option to hide/show faders on the Sisyfos GUI

* **What is the new behavior (if this is a feature change)?**
When setting visible: false - the fader is hidden on the GUI but still controlled from Sofie

