### PR TITLE
feat(CasparCG): retry media that failed to load

### DIFF
--- a/src/__tests__/rundown.spec.ts
+++ b/src/__tests__/rundown.spec.ts
@@ -77,7 +77,8 @@ describe('Rundown', () => {
 				commandReceiver: commandReceiver0,
 				host: '127.0.0.1',
 				timeBase: 50,
-				useScheduling: true
+				useScheduling: true,
+				disableRetries: true
 			}
 		})
 		await myConductor.setMapping(myLayerMapping)

--- a/src/__tests__/rundown.spec.ts
+++ b/src/__tests__/rundown.spec.ts
@@ -78,7 +78,7 @@ describe('Rundown', () => {
 				host: '127.0.0.1',
 				timeBase: 50,
 				useScheduling: true,
-				disableRetries: true
+				retryInterval: false
 			}
 		})
 		await myConductor.setMapping(myLayerMapping)

--- a/src/types/src/casparcg.ts
+++ b/src/types/src/casparcg.ts
@@ -16,6 +16,7 @@ export interface CasparCGOptions {
 
 	/** whether to use the CasparCG-SCHEDULE command to run future commands, or the internal (backwards-compatible) command queue */
 	useScheduling?: boolean
+	disableRetries?: boolean
 	/* Timecode base of channel */
 	timeBase?: {[channel: string]: number} | number
 

--- a/src/types/src/casparcg.ts
+++ b/src/types/src/casparcg.ts
@@ -16,7 +16,7 @@ export interface CasparCGOptions {
 
 	/** whether to use the CasparCG-SCHEDULE command to run future commands, or the internal (backwards-compatible) command queue */
 	useScheduling?: boolean
-	disableRetries?: boolean
+	retryInterval?: number | boolean // set to false to disable, 0 or true will set to default value
 	/* Timecode base of channel */
 	timeBase?: {[channel: string]: number} | number
 


### PR DESCRIPTION
This pull requests adds support for retrying media through using the state tracking feature of the CasparCG state library.

Specifically only media commands are selected from the diff result as newly added commands over the last while may not be supported by this mechanism and therefore should not be retried.