### PR TITLE
Feat/clear commands

### DIFF
--- a/src/__mocks__/v-connection.ts
+++ b/src/__mocks__/v-connection.ts
@@ -79,7 +79,8 @@ export class MSEMock extends EventEmitter implements MSE {
 	}
 	async getProfile (profileName: string): Promise<VProfile> {
 		return {
-			name: profileName
+			name: profileName,
+			execution_groups: {}
 		}
 	}
 	async listShows (): Promise<string[]> {
@@ -125,7 +126,8 @@ export class MSEMock extends EventEmitter implements MSE {
 	}
 	async createProfile (profileName: string, _profileDetailsTbc: any): Promise<VProfile> {
 		const profile: VProfile = {
-			name: profileName
+			name: profileName,
+			execution_groups: {}
 		}
 		this.profiles[profileName] = profile
 

--- a/src/devices/__tests__/vizMSE.spec.ts
+++ b/src/devices/__tests__/vizMSE.spec.ts
@@ -610,7 +610,8 @@ describe('vizMSE', () => {
 				playlistID: 'my-super-playlist-id',
 				showID: 'show1234',
 				profile: 'profile9999',
-				clearAllTemplateName: 'clear_all_of_them'
+				clearAllTemplateName: 'clear_all_of_them',
+				clearAllCommands: ['RENDERER*FRONT_LAYER SET_OBJECT ', 'RENDERER SET_OBJECT ']
 			}
 		})
 		await mockTime.advanceTimeToTicks(10100)
@@ -646,7 +647,9 @@ describe('vizMSE', () => {
 				layer: 'viz0',
 				content: {
 					deviceType: DeviceType.VIZMSE,
-					type: TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS
+					type: TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS,
+					channelsToSendCommands: ['OVL', 'FULL'],
+					commands: ['RENDERER*FRONT_LAYER SET_OBJECT ', 'RENDERER SET_OBJECT ']
 				}
 			}
 		]
@@ -690,7 +693,7 @@ describe('vizMSE', () => {
 
 		commandReceiver0.mockClear()
 		await mockTime.advanceTimeToTicks(15500)
-		expect(commandReceiver0.mock.calls.length).toEqual(2)
+		expect(commandReceiver0.mock.calls.length).toEqual(3)
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			timelineObjId: 'clearAll',
 			time: 15100,
@@ -698,6 +701,13 @@ describe('vizMSE', () => {
 			templateName: 'clear_all_of_them'
 		})
 		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
+			timelineObjId: 'clearAll',
+			time: 15100,
+			type: 'clear_all_engines',
+			channels: ['OVL', 'FULL'],
+			commands: ['RENDERER*FRONT_LAYER SET_OBJECT ', 'RENDERER SET_OBJECT ']
+		})
+		expect(getMockCall(commandReceiver0, 2, 1)).toMatchObject({
 			timelineObjId: 'obj0',
 			time: 15150,
 			templateInstance: expect.stringContaining('myInternalElement'),

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -41,6 +41,7 @@ import {
 import { DoOnTime, SendMode } from '../doOnTime'
 
 import * as crypto from 'crypto'
+import * as net from 'net'
 
 /** The ideal time to prepare elements before going on air */
 const IDEAL_PREPARE_TIME = 1000
@@ -266,7 +267,8 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 					} else if (l.content.type === TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS) {
 						// Special case: clear all graphics:
 						state.isClearAll = {
-							timelineObjId: l.id
+							timelineObjId: l.id,
+							channelsToSendCommands: l.content.channelsToSendCommands
 						}
 
 					} else if (l.content.type === TimelineContentTypeVizMSE.CONTINUE) {
@@ -342,15 +344,25 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 			if (this._vizmseManager) {
 				if (
 					this._initOptions &&
-					this._initOptions.clearAllOnMakeReady &&
-					this._initOptions.clearAllTemplateName
+					this._initOptions.clearAllOnMakeReady
 				) {
-					await this._vizmseManager.clearAll({
-						type: VizMSECommandType.CLEAR_ALL_ELEMENTS,
-						time: this.getCurrentTime(),
-						timelineObjId: 'makeReady',
-						templateName: this._initOptions.clearAllTemplateName
-					})
+					if (this._initOptions.clearAllTemplateName) {
+						await this._vizmseManager.clearAll({
+							type: VizMSECommandType.CLEAR_ALL_ELEMENTS,
+							time: this.getCurrentTime(),
+							timelineObjId: 'makeReady',
+							templateName: this._initOptions.clearAllTemplateName
+						})
+					}
+					if (this._initOptions.clearAllCommands && this._initOptions.clearAllCommands.length) {
+						await this._vizmseManager.clearEngines({
+							type: VizMSECommandType.CLEAR_ALL_ENGINES,
+							time: this.getCurrentTime(),
+							timelineObjId: 'makeReady',
+							channels: 'all',
+							commands: this._initOptions.clearAllCommands
+						})
+					}
 				}
 			} else throw new Error(`Unable to activate vizMSE, not initialized yet!`)
 		}
@@ -584,21 +596,33 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 		if (newState.isClearAll && !oldState.isClearAll) {
 			// Special: clear all graphics
 
+			const clearingCommands: VizMSECommand[] = []
+
 			const templateName = this._initOptions && this._initOptions.clearAllTemplateName
 			if (!templateName) {
 				this.emit('warning', `vizMSE: initOptions.clearAllTemplateName is not set!`)
 			} else {
 
 				// Start playing special element:
-				return [
-					literal<VizMSECommandClearAllElements>({
-						timelineObjId: newState.isClearAll.timelineObjId,
-						time: time,
-						type: VizMSECommandType.CLEAR_ALL_ELEMENTS,
-						templateName: templateName
-					})
-				]
+				clearingCommands.push(literal<VizMSECommandClearAllElements>({
+					timelineObjId: newState.isClearAll.timelineObjId,
+					time: time,
+					type: VizMSECommandType.CLEAR_ALL_ELEMENTS,
+					templateName: templateName
+				}))
 			}
+			if (newState.isClearAll.channelsToSendCommands && this._initOptions && this._initOptions.clearAllCommands && this._initOptions.clearAllCommands.length) {
+
+				// Send special commands to the engines:
+				clearingCommands.push(literal<VizMSECommandClearAllEngines>({
+					timelineObjId: newState.isClearAll.timelineObjId,
+					time: time,
+					type: VizMSECommandType.CLEAR_ALL_ENGINES,
+					channels: newState.isClearAll.channelsToSendCommands,
+					commands: this._initOptions.clearAllCommands
+				}))
+			}
+			return clearingCommands
 		}
 		const sortCommands = (commands: VizMSECommand[]): VizMSECommand[] => {
 			// Sort the commands so that take out:s are run first
@@ -705,6 +729,8 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 					await this._vizmseManager.loadAllElements(cmd)
 				} else if (cmd.type === VizMSECommandType.CLEAR_ALL_ELEMENTS) {
 					await this._vizmseManager.clearAll(cmd)
+				} else if (cmd.type === VizMSECommandType.CLEAR_ALL_ENGINES) {
+					await this._vizmseManager.clearEngines(cmd)
 				} else {
 					// @ts-ignore never
 					throw new Error(`Unsupported command type "${cmd.type}"`)
@@ -1015,6 +1041,44 @@ class VizMSEManager extends EventEmitter {
 			this.emit('debug', `VizMSE: clearAll take "${elementRef}"`)
 			return rundown.take(elementRef)
 		})
+	}
+	/**
+	 * Special: send commands to Viz Engines in order to clear them
+	 */
+	public async clearEngines (cmd: VizMSECommandClearAllEngines): Promise<void> {
+		try {
+			const profile = await this._vizMSE.getProfile(this._profile)
+			const engines = await this._vizMSE.getEngines()
+			const outputs = new Map<string, string>() // engine name : channel name
+			_.each(profile.execution_groups, (group, groupName) => {
+				_.each(group, entry => {
+					if (typeof entry === 'object' && entry.viz) {
+						if (typeof entry.viz === 'object' && entry.viz.value) {
+							outputs.set(entry.viz.value as string, groupName)
+						}
+					}
+				})
+			})
+			const outputEngines = engines.filter(engine => {
+				return outputs.has(engine.name)
+			})
+			outputEngines.forEach(engine => {
+				_.each(_.keys(engine.renderer), host => {
+					const channelName = outputs.get(engine.name)
+					if (cmd.channels === 'all' || _.contains(cmd.channels, channelName)) {
+						const match = host.match(/([^:]+):?(\d*)?/)
+						const port = (match && match[2]) ? parseInt(match[2], 10) : 6100
+						const hostname = (match && match[1]) ? match[1] : host
+						const sender = new VizEngineTcpSender(port, hostname)
+						sender.on('warning', w => this.emit('warning', `clearEngines: ${w}`))
+						sender.on('error', e => this.emit('error', `clearEngines: ${e}`))
+						sender.send(cmd.commands)
+					}
+				})
+			})
+		} catch (e) {
+			this.emit('warning', `Sending command failed`, e)
+		}
 	}
 	/**
 	 * Load all elements: Trigger a loading of all pilot elements onto the vizEngine.
@@ -1587,7 +1651,8 @@ interface VizMSEState {
 	}
 	/** Special: If this is set, all other state will be disregarded and all graphics will be cleared */
 	isClearAll?: {
-		timelineObjId: string
+		timelineObjId: string,
+		channelsToSendCommands?: string[]
 	}
 }
 type VizMSEStateLayer = VizMSEStateLayerInternal | VizMSEStateLayerPilot | VizMSEStateLayerContinue | VizMSEStateLayerLoadAllElements
@@ -1642,7 +1707,8 @@ export enum VizMSECommandType {
 	CONTINUE_ELEMENT = 'continue',
 	CONTINUE_ELEMENT_REVERSE = 'continuereverse',
 	LOAD_ALL_ELEMENTS = 'load_all_elements',
-	CLEAR_ALL_ELEMENTS = 'clear_all_elements'
+	CLEAR_ALL_ELEMENTS = 'clear_all_elements',
+	CLEAR_ALL_ENGINES = 'clear_all_engines'
 }
 
 interface VizMSECommandElementBase extends VizMSECommandBase, VizMSEPlayoutItemContentInternal {
@@ -1675,6 +1741,12 @@ interface VizMSECommandClearAllElements extends VizMSECommandBase {
 
 	templateName: string
 }
+interface VizMSECommandClearAllEngines extends VizMSECommandBase {
+	type: VizMSECommandType.CLEAR_ALL_ENGINES
+
+	channels: string[] | 'all'
+	commands: string[]
+}
 
 type VizMSECommand = VizMSECommandPrepare |
 	VizMSECommandCue |
@@ -1683,7 +1755,8 @@ type VizMSECommand = VizMSECommandPrepare |
 	VizMSECommandContinue |
 	VizMSECommandContinueReverse |
 	VizMSECommandLoadAllElements |
-	VizMSECommandClearAllElements
+	VizMSECommandClearAllElements |
+	VizMSECommandClearAllEngines
 
 interface VizMSEPlayoutItemContentInternal extends VIZMSEPlayoutItemContent {
 	/** Name of the instance of the element in MSE, generated by us */
@@ -1733,4 +1806,77 @@ function content2StateLayer (
 		return o
 	}
 	return
+}
+
+class VizEngineTcpSender extends EventEmitter {
+	private _socket: net.Socket = new net.Socket()
+	private _port: number
+	private _host: string
+	private _connected: boolean = false
+	private _commandCount: number = 0
+	private _sendQueue: string[] = []
+	private _waitQueue: Set<number> = new Set()
+	private _incomingData: string = ''
+
+	constructor (port: number, host: string) {
+		super()
+		this._port = port
+		this._host = host
+	}
+
+	send (commands: string[]) {
+		commands.forEach(command => {
+			this._sendQueue.push(command)
+		})
+		if (this._connected) {
+			this._flushQueue()
+		} else {
+			this._connect()
+		}
+	}
+
+	private _connect () {
+		this._socket = net.createConnection(this._port, this._host)
+		this._socket.on('connect', () => {
+			this._connected = true
+			this._flushQueue()
+		})
+		this._socket.on('error', e => {
+			this.emit('error', e)
+		})
+		this._socket.on('lookup', () => {
+			// this handles a dns exception, but the error is handled on 'error' event
+		})
+		this._socket.on('data', this._processData.bind(this))
+	}
+
+	private _flushQueue () {
+		this._sendQueue.forEach(command => {
+			this._socket.write(`${++this._commandCount} ${command}\x00`)
+			this._waitQueue.add(this._commandCount)
+		})
+	}
+
+	private _processData (data: Buffer) {
+		this._incomingData = this._incomingData.concat(data.toString())
+		let split = this._incomingData.split('\x00')
+		if (split.length === 0 || split.length === 1 && split[0] === '') return
+		if (split[split.length - 1] !== '') {
+			this._incomingData = split.pop()!
+		} else {
+			this._incomingData = ''
+		}
+		split.forEach(message => {
+			const firstSpace = message.indexOf(' ')
+			const id = message.substr(0, firstSpace)
+			const contents = message.substr(firstSpace + 1)
+			if (contents.startsWith('ERROR')) {
+				this.emit('warning', contents)
+			}
+			this._waitQueue.delete(parseInt(id, 10))
+		})
+		if (this._waitQueue.size === 0) {
+			this._socket.destroy()
+		}
+	}
 }

--- a/src/types/src/vizMSE.ts
+++ b/src/types/src/vizMSE.ts
@@ -37,6 +37,8 @@ export interface VizMSEOptions {
 	dontDeactivateOnStandDown?: boolean
 	/** If true, only elements in the currently active rundown will be loaded */
 	onlyPreloadActiveRundown?: boolean
+	/** List of commands to be sent to Viz Engines in order to fully clear them */
+	clearAllCommands?: string[]
 }
 export enum TimelineContentTypeVizMSE {
 	ELEMENT_INTERNAL = 'element_internal',
@@ -145,6 +147,9 @@ export interface TimelineObjVIZMSEClearAllElements extends TSRTimelineObjBase {
 	content: {
 		deviceType: DeviceType.VIZMSE
 		type: TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS
+
+		/** Names of the channels to send the special clear commands to */
+		channelsToSendCommands?: string[]
 	}
 }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds a feature to send custom commands to Viz Engines chosen based on the provided channel names, in order to clear their output.

List of the commands is provided in `clearAllCommands` option.
The channels to which the commands will be sent is provided via `channelsToSendCommands` in `TimelineObjVIZMSEClearAllElements`, and that Timeline Object triggers sending of the commands.
The commands are also sent to **all** the engines in the profile on `makeReady`, when `clearAllOnMakeReady` option is true.

It depends on https://github.com/olzzon/v-connection/pull/4