### PR TITLE
feat: Add external elements status reporting using Media Objects

### DIFF
--- a/src/devices/device.ts
+++ b/src/devices/device.ts
@@ -8,6 +8,7 @@ import {
 import { EventEmitter } from 'events'
 import { CommandReport, DoOnTime } from '../doOnTime'
 import { DeviceInitOptions, DeviceOptionsAny } from '../types/src/device'
+import { MediaObject } from '../types/src/mediaObject'
 /*
 	This is a base class for all the Device wrappers.
 	The Device wrappers will
@@ -227,7 +228,11 @@ export abstract class Device extends EventEmitter implements IDevice {
 		/** A report that a command was sent too late */
 		((event: 'slowCommand',			listener: (commandInfo: string) => void) => this) &
 		/** Something went wrong when executing a command  */
-		((event: 'commandError', 		listener: (error: Error, context: CommandWithContext) => void) => this)
+		((event: 'commandError', 		listener: (error: Error, context: CommandWithContext) => void) => this) &
+		/** Update a MediaObject  */
+		((event: 'updateMediaObject',	listener: (collectionId: string, docId: string, doc: MediaObject | null) => void) => this) &
+		/** Clear a MediaObjects collection */
+		((event: 'clearMediaObjects',	listener: (collectionId: string) => void) => this)
 
 		// Overide EventEmitter.emit() for stronger typings:
 	emit: ((event: 'info',				info: string) => boolean) &
@@ -238,7 +243,9 @@ export abstract class Device extends EventEmitter implements IDevice {
 		((event: 'resetResolver') => boolean) &
 		((event: 'slowCommand',			commandInfo: string) => boolean) &
 		((event: 'commandReport',		commandReport: CommandReport) => boolean) &
-		((event: 'commandError',		error: Error, context: CommandWithContext) => boolean)
+		((event: 'commandError',		error: Error, context: CommandWithContext) => boolean) &
+		((event: 'updateMediaObject',	collectionId: string, docId: string, doc: MediaObject | null) => boolean) &
+		((event: 'clearMediaObjects',	collectionId: string) => boolean)
 
 	public get instanceId (): number {
 		return this._instanceId

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -44,6 +44,7 @@ import { DoOnTime, SendMode } from '../doOnTime'
 
 import * as crypto from 'crypto'
 import * as net from 'net'
+import { MediaObject } from '../types/src/mediaObject'
 
 /** The ideal time to prepare elements before going on air */
 const IDEAL_PREPARE_TIME = 1000
@@ -129,6 +130,8 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 		)
 
 		this._vizmseManager.on('connectionChanged', (connected) => this.connectionChanged(connected))
+		this._vizmseManager.on('updateMediaObject', (collectionId: string, docId: string, doc: MediaObject | null) => this.emit('updateMediaObject', collectionId, docId, doc))
+		this._vizmseManager.on('clearMediaObjects', (collectionId: string) => this.emit('clearMediaObjects', collectionId))
 
 		this._vizmseManager.on('info', str => this.emit('info', 'VizMSE: ' + str))
 		this._vizmseManager.on('warning', str => this.emit('warning', 'VizMSE' + str))
@@ -906,6 +909,7 @@ class VizMSEManager extends EventEmitter {
 			this.emit('error', error)
 		}
 		this._clearCache()
+		this._clearMediaObjects()
 
 		this._triggerCommandSent()
 		await this._triggerLoadAllElements(true)
@@ -922,9 +926,13 @@ class VizMSEManager extends EventEmitter {
 		await rundown.deactivate()
 		this._triggerCommandSent()
 		this.standDownActiveRundown()
+		this._clearMediaObjects()
 	}
 	public standDownActiveRundown (): void {
 		this._hasActiveRundown = false
+	}
+	private _clearMediaObjects (): void {
+		this.emit('clearMediaObjects', this._parentVizMSEDevice.deviceId)
 	}
 	/**
 	 * Prepare an element
@@ -1363,6 +1371,25 @@ class VizMSEManager extends EventEmitter {
 								isLoading: this._isElementLoading(newEl)
 							}
 							this.emit('debug', `Element ${elementRef}: ${JSON.stringify(newEl)}`)
+							if (this._isExternalElement(newEl)) {
+								if (this._elementsLoaded[e.hash].isLoaded) {
+									const mediaObject: MediaObject = {
+										_id: e.hash,
+										mediaId: 'PILOT_' + e.item.templateName.toString().toUpperCase(),
+										mediaPath: e.item.templateInstance,
+										mediaSize: 0,
+										mediaTime: 0,
+										thumbSize: 0,
+										thumbTime: 0,
+										cinf: '',
+										tinf: '',
+										_rev: ''
+									}
+									this.emit('updateMediaObject', this._parentVizMSEDevice.deviceId, e.hash, mediaObject)
+								} else if (!cachedEl) {
+									this.emit('updateMediaObject', this._parentVizMSEDevice.deviceId, e.hash, null)
+								}
+							}
 						} catch (e) {
 							this.emit('error', `Error in updateElementsLoadedStatus: ${e.toString()}`)
 						}

--- a/src/types/src/index.ts
+++ b/src/types/src/index.ts
@@ -37,6 +37,7 @@ import { TimelineObjSingularLiveAny } from './singularLive'
 export { Timeline }
 export * from './mapping'
 export * from './expectedPlayoutItems'
+export * from './mediaObject'
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 

--- a/src/types/src/mediaObject.ts
+++ b/src/types/src/mediaObject.ts
@@ -1,0 +1,35 @@
+export interface MediaInfo {
+	name: string
+}
+
+export interface MediaObject {
+	/** The playable reference (CasparCG clip name, quantel GUID, etc) */
+	mediaId: string
+
+	/** Media object file path relative to playout server */
+	mediaPath: string
+	/** Media object size in bytes */
+	mediaSize: number
+	/** Timestamp when the media object was last updated */
+	mediaTime: number
+	/** Info about media content. If undefined: inficates that the media is NOT playable (could be transferring, or a placeholder)  */
+	mediainfo?: MediaInfo
+
+	/** Thumbnail file size in bytes */
+	thumbSize: number
+	/** Thumbnail last updated timestamp */
+	thumbTime: number
+
+	/** Preview file size in bytes */
+	previewSize?: number
+	/** Thumbnail last updated timestamp */
+	previewTime?: number
+	/** Preview location */
+	previewPath?: string
+
+	cinf: string // useless to us
+	tinf: string // useless to us
+
+	_id: string
+	_rev: string
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds reporting loading status of External Elements (Pilot) in Viz device, by creating/removing Media Objects in core's collection. New `updateMediaObject` and `clearMediaObjects` events, that have to be handled by the Playout Gateway, are added.
