### PR TITLE
fix(sisyfos): Sorting all channels by overridePriority

### DIFF
--- a/src/devices/sisyfos.ts
+++ b/src/devices/sisyfos.ts
@@ -252,6 +252,14 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 	convertStateToSisyfosState (state: TimelineState, mappings: Mappings) {
 		const deviceState: SisyfosState = this.getDeviceState()
 
+		// Preparation: put all channels that comes from the state in an array:
+		const newChannels: ({
+			overridePriority: number,
+			channel: number,
+			isLookahead: boolean
+			tlObjId: string
+		} & SisyfosChannelOptions)[] = []
+
 		_.each(state.layers, (tlObject, layerName) => {
 			const layer = tlObject as ResolvedTimelineObjectInstance & TimelineObjSisyfosAny
 			let foundMapping = mappings[layerName] as MappingSisyfos | undefined
@@ -268,13 +276,6 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 				foundMapping = mappings[layer.lookaheadForLayer] as MappingSisyfos | undefined
 			}
 
-			// Preparation: put all channels that comes from the state in an array:
-			const newChannels: ({
-				overridePriority: number,
-				channel: number,
-				isLookahead: boolean
-				tlObjId: string
-			} & SisyfosChannelOptions)[] = []
 			if (foundMapping && foundMapping.deviceId === this.deviceId) {
 				// @ts-ignore backwards-compatibility:
 				if (!foundMapping.mappingType) foundMapping.mappingType = MappingSisyfosType.CHANNEL
@@ -313,31 +314,32 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 				deviceState.resync = deviceState.resync || content.resync || false
 			}
 
-			// Sort by overridePriority, so that those with highest overridePriority will be applied last
-			_.each(
-				_.sortBy(newChannels, channel => channel.overridePriority),
-				newChannel => {
-					if (!deviceState.channels[newChannel.channel]) {
-						deviceState.channels[newChannel.channel] = this.getDefaultStateChannel()
-					}
-					const channel = deviceState.channels[newChannel.channel]
-
-					if (newChannel.isPgm !== undefined) {
-						if (newChannel.isLookahead) {
-							channel.pstOn = newChannel.isPgm || 0
-						} else {
-							channel.pgmOn = newChannel.isPgm || 0
-						}
-					}
-
-					if (newChannel.faderLevel !== undefined) channel.faderLevel = newChannel.faderLevel
-					if (newChannel.label !== undefined) channel.label = newChannel.label
-					if (newChannel.visible !== undefined) channel.visible = newChannel.visible
-
-					channel.tlObjIds.push(tlObject.id)
-				}
-			)
 		})
+
+		// Sort by overridePriority, so that those with highest overridePriority will be applied last
+		_.each(
+			_.sortBy(newChannels, channel => channel.overridePriority),
+			newChannel => {
+				if (!deviceState.channels[newChannel.channel]) {
+					deviceState.channels[newChannel.channel] = this.getDefaultStateChannel()
+				}
+				const channel = deviceState.channels[newChannel.channel]
+
+				if (newChannel.isPgm !== undefined) {
+					if (newChannel.isLookahead) {
+						channel.pstOn = newChannel.isPgm || 0
+					} else {
+						channel.pgmOn = newChannel.isPgm || 0
+					}
+				}
+
+				if (newChannel.faderLevel !== undefined) channel.faderLevel = newChannel.faderLevel
+				if (newChannel.label !== undefined) channel.label = newChannel.label
+				if (newChannel.visible !== undefined) channel.visible = newChannel.visible
+
+				channel.tlObjIds.push(newChannel.tlObjId)
+			}
+		)
 		return deviceState
 	}
 	get deviceType () {


### PR DESCRIPTION
Fixes a bug causing unexpected behavior of Sisyfos channels when there are Timeline Objects affecting a channels across multiple layers.
Sort and apply all the channels at the end, instead of per layer, because one channel may be affected by objects from multiple layers.