### PR TITLE
fix: make disabling Caspar retry possible

### DIFF
--- a/src/devices/casparCG.ts
+++ b/src/devices/casparCG.ts
@@ -152,7 +152,7 @@ export class CasparCGDevice extends DeviceWithState<State> implements IDevice {
 			}
 		}) as ChannelInfo[], this.getCurrentTime())
 
-		if (typeof initOptions.retryInterval === 'number') {
+		if (typeof initOptions.retryInterval === 'number' && initOptions.retryInterval >= 0) {
 			this._retryTime = initOptions.retryInterval || MEDIA_RETRY_INTERVAL
 			this._retryTimeout = setTimeout(() => this._assertIntendedState(), this._retryTime)
 		}

--- a/src/types/src/casparcg.ts
+++ b/src/types/src/casparcg.ts
@@ -16,7 +16,8 @@ export interface CasparCGOptions {
 
 	/** whether to use the CasparCG-SCHEDULE command to run future commands, or the internal (backwards-compatible) command queue */
 	useScheduling?: boolean
-	retryInterval?: number | boolean // set to false to disable, 0 or true will set to default value
+	/** Interval (ms) for retrying to load media that previously failed. (-1 disables, 0 uses the default interval) */
+	retryInterval?: number
 	/* Timecode base of channel */
 	timeBase?: {[channel: string]: number} | number
 	/* fps used for all channels */


### PR DESCRIPTION
There used to be no way of disabling it through the device config