### PR TITLE
Fix: Viz fixes and minor features

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "underscore": "^1.10.2",
     "underscore-deep-extend": "^1.1.5",
     "utf-8-validate": "^5.0.2",
-    "v-connection": "git+https://github.com/olzzon/v-connection#v20200515_1",
+    "v-connection": "git+https://github.com/olzzon/v-connection#vtest20210413_1",
     "ws": "^7.1.1",
     "xml-js": "^1.6.11"
   },

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "tslint": "^6.1.2",
     "tslint-config-standard": "^9.0.0",
     "typedoc": "^0.16.0",
-    "typescript": "3.6.x"
+    "typescript": "3.8.x"
   },
   "keywords": [
     "broadcast",
@@ -176,7 +176,7 @@
     "underscore": "^1.10.2",
     "underscore-deep-extend": "^1.1.5",
     "utf-8-validate": "^5.0.2",
-    "v-connection": "git+https://github.com/olzzon/v-connection#vtest20210413_1",
+    "v-connection": "git+https://github.com/olzzon/v-connection#v20210604_1",
     "ws": "^7.1.1",
     "xml-js": "^1.6.11"
   },

--- a/src/__mocks__/v-connection.ts
+++ b/src/__mocks__/v-connection.ts
@@ -9,7 +9,8 @@ import {
 	VTemplate,
 	InternalElement,
 	ExternalElement,
-	VElement
+	VElement,
+	ExternalElementId
 } from 'v-connection'
 import { EventEmitter } from 'events'
 import { CommandResult } from 'v-connection/dist/msehttp'
@@ -175,7 +176,7 @@ type MockClass<T> = {
 export type VRundownMocked = MockClass<VRundown>
 export class VRundownMock implements VRundown {
 	private elements: {[key: string]: VElement} = {}
-	private _isActive: Boolean = false
+	private _isActive: boolean = false
 	constructor (
 		public readonly show: string,
 		public readonly profile: string,
@@ -301,10 +302,10 @@ export class VRundownMock implements VRundown {
 	async cleanup (): Promise<CommandResult> {
 		return { path: '', status: 200, response: 'mock' }
 	}
-	async purge (): Promise<PepResponse> {
+	async purge (_elementsToKeep?: ExternalElementId[]): Promise<PepResponse> {
 		return { id: '*', status: 'ok', body: 'mock' }
 	}
-	async isActive (): Promise<Boolean> {
+	async isActive (): Promise<boolean> {
 		return this._isActive
 	}
 }

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -272,7 +272,7 @@ export class Conductor extends EventEmitter {
 	 * @param deviceOptions The options used to initalize the device
 	 * @returns A promise that resolves with the created device, or rejects with an error message.
 	 */
-	public async addDevice (deviceId: string, deviceOptions: DeviceOptionsAnyInternal): Promise<DeviceContainer> {
+	public async addDevice (deviceId: string, deviceOptions: DeviceOptionsAnyInternal, activeRundownPlaylistId?: string): Promise<DeviceContainer> {
 		try {
 			let newDevice: DeviceContainer
 			let threadedClassOptions = {
@@ -476,7 +476,7 @@ export class Conductor extends EventEmitter {
 
 			// TODO - should the device be on this.devices yet? sounds like we could instruct it to do things before it has initialised?
 
-			await newDevice.device.init(deviceOptions.options)
+			await newDevice.device.init(deviceOptions.options, activeRundownPlaylistId)
 
 			await newDevice.reloadProps() // because the device name might have changed after init
 

--- a/src/devices/__tests__/vizMSE.spec.ts
+++ b/src/devices/__tests__/vizMSE.spec.ts
@@ -333,6 +333,7 @@ describe('vizMSE', () => {
 		rundown.createElement.mockClear()
 
 		await myConductor.devicesMakeReady(true)
+		await mockTime.advanceTimeTicks(10)
 
 		expect(rundown.activate).toHaveBeenCalledTimes(2)
 

--- a/src/devices/device.ts
+++ b/src/devices/device.ts
@@ -44,7 +44,7 @@ export interface DeviceStatus {
 export function literal<T> (o: T) { return o }
 
 export interface IDevice {
-	init: (initOptions: DeviceInitOptions) => Promise<boolean>
+	init: (initOptions: DeviceInitOptions, activeRundownPlaylistId: string | undefined) => Promise<boolean>
 
 	getCurrentTime: () => number
 

--- a/src/devices/device.ts
+++ b/src/devices/device.ts
@@ -1,14 +1,12 @@
 import * as _ from 'underscore'
 import { TimelineState } from 'superfly-timeline'
-import {
-	Mappings,
-	DeviceType,
-	ExpectedPlayoutItemContent
-} from '../types/src'
+import { Mappings, DeviceType } from '../types/src'
 import { EventEmitter } from 'events'
 import { CommandReport, DoOnTime } from '../doOnTime'
 import { DeviceInitOptions, DeviceOptionsAny } from '../types/src/device'
 import { MediaObject } from '../types/src/mediaObject'
+import { ExpectedPlayoutItem } from '../expectedPlayoutItems'
+
 /*
 	This is a base class for all the Device wrappers.
 	The Device wrappers will
@@ -189,7 +187,7 @@ export abstract class Device extends EventEmitter implements IDevice {
 	get supportsExpectedPlayoutItems (): boolean {
 		return false
 	}
-	public handleExpectedPlayoutItems (_expectedPlayoutItems: Array<ExpectedPlayoutItemContent>): void {
+	public handleExpectedPlayoutItems (_expectedPlayoutItems: Array<ExpectedPlayoutItem>): void {
 		// When receiving a new list of playoutItems.
 		// by default, do nothing
 	}

--- a/src/devices/sisyfos.ts
+++ b/src/devices/sisyfos.ts
@@ -263,7 +263,7 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState> implemen
 
 			if (!channel) {
 				channel = this.getDefaultStateChannel()
-				
+
 			}
 
 			channel.label = sisyfosMapping.layerName

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -917,7 +917,7 @@ class VizMSEManager extends EventEmitter {
 			// clear any existing elements from the existing rundown
 			try {
 				this.emit('debug', `VizMSE: purging rundown`)
-				const elementsToKeep = (this._expectedPlayoutItems.filter((item) => !item.playlistId && _.isNumber(item.templateName)) as { templateName: number, channelName?: string }[]).map((item => ({ vcpid: item.templateName, channelName: item.channelName })))
+				const elementsToKeep = (this._expectedPlayoutItems.filter((item) => item.baseline && _.isNumber(item.templateName)) as { templateName: number, channelName?: string }[]).map((item => ({ vcpid: item.templateName, channelName: item.channelName })))
 				await rundown.purge(elementsToKeep)
 			} catch (error) {
 				this.emit('error', error)

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -968,7 +968,7 @@ class VizMSEManager extends EventEmitter {
 	public async prepareElement (cmd: VizMSECommandPrepare): Promise<void> {
 
 		const elementHash = this.getElementHash(cmd)
-		this.emit('debug', `VizMSE: prepare "${elementHash}"`)
+		this.emit('debug', `VizMSE: prepare "${elementHash}" on channel "${cmd.channelName}"`)
 		this._triggerCommandSent()
 		await this._checkPrepareElement(cmd, true)
 		this._triggerCommandSent()
@@ -983,7 +983,7 @@ class VizMSEManager extends EventEmitter {
 
 		await this._checkElementExists(cmd)
 		await this._handleRetry(() => {
-			this.emit('debug', `VizMSE: cue "${elementRef}"`)
+			this.emit('debug', `VizMSE: cue "${elementRef}" on channel "${cmd.channelName}"`)
 			return rundown.cue(elementRef)
 		})
 	}
@@ -1006,7 +1006,7 @@ class VizMSEManager extends EventEmitter {
 
 		await this._checkElementExists(cmd)
 		await this._handleRetry(() => {
-			this.emit('debug', `VizMSE: take "${elementRef}"`)
+			this.emit('debug', `VizMSE: take "${elementRef}" on channel "${cmd.channelName}"`)
 
 			return rundown.take(elementRef)
 		})
@@ -1030,7 +1030,7 @@ class VizMSEManager extends EventEmitter {
 
 		await this._checkElementExists(cmd)
 		await this._handleRetry(() => {
-			this.emit('debug', `VizMSE: out "${elementRef}"`)
+			this.emit('debug', `VizMSE: out "${elementRef}" on channel "${cmd.channelName}"`)
 			return rundown.out(elementRef)
 		})
 	}
@@ -1044,7 +1044,7 @@ class VizMSEManager extends EventEmitter {
 
 		await this._checkElementExists(cmd)
 		await this._handleRetry(() => {
-			this.emit('debug', `VizMSE: continue "${elementRef}"`)
+			this.emit('debug', `VizMSE: continue "${elementRef}" on channel "${cmd.channelName}"`)
 			return rundown.continue(elementRef)
 		})
 	}
@@ -1058,7 +1058,7 @@ class VizMSEManager extends EventEmitter {
 
 		await this._checkElementExists(cmd)
 		await this._handleRetry(() => {
-			this.emit('debug', `VizMSE: continue reverse "${elementRef}"`)
+			this.emit('debug', `VizMSE: continue reverse "${elementRef}" on channel "${cmd.channelName}"`)
 			return rundown.continueReverse(elementRef)
 		})
 	}

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -1339,7 +1339,7 @@ class VizMSEManager extends EventEmitter {
 						hashesAndItems[this.getElementHash(item)] = item
 					}
 				} catch (e) {
-					this.emit('error', `Error in _getExpectedPlayoutItems: ${e.toString()}`)
+					this.emit('error', `Error in _getExpectedPlayoutItems for "${expectedPlayoutItem.templateName}": ${e.toString()}`)
 				}
 			})
 		)

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -822,6 +822,7 @@ class VizMSEManager extends EventEmitter {
 	public async initializeRundown (activeRundownPlaylistId: string | undefined): Promise<void> {
 		this._vizMSE.on('connected', () => this.mseConnectionChanged(true))
 		this._vizMSE.on('disconnected', () => this.mseConnectionChanged(false))
+		this._activeRundownPlaylistId = activeRundownPlaylistId
 		this._preloadedRundownPlaylistId = this.onlyPreloadActivePlaylist ? activeRundownPlaylistId : undefined
 
 		if (activeRundownPlaylistId) {

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -1295,7 +1295,7 @@ class VizMSEManager extends EventEmitter {
 
 		const hashesAndItems: {[hash: string]: VizMSEPlayoutItemContentInternal} = {}
 
-		const expectedPlayoutItems = _.filter(this._expectedPlayoutItems, expectedPlayoutItem => {
+		const expectedPlayoutItems = _.uniq(_.filter(this._expectedPlayoutItems, expectedPlayoutItem => {
 			const templateName = typeof expectedPlayoutItem.templateName as string | number | undefined
 			return (
 				(
@@ -1304,7 +1304,7 @@ class VizMSEManager extends EventEmitter {
 				) &&
 				typeof templateName !== 'undefined'
 			)
-		})
+		}), false, (a) => JSON.stringify(_.pick(a, 'templateName', 'templateData', 'channelName')))
 
 		await Promise.all(
 			_.map(expectedPlayoutItems, async expectedPlayoutItem => {

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -1528,7 +1528,7 @@ class VizMSEManager extends EventEmitter {
 	private async _pingEngine (engine: Engine): Promise<EngineStatus> {
 		return new Promise((resolve, _reject) => {
 			request.get(`http://${engine.host}:${this.engineRestPort}/#/status`, { timeout: 2000 }, (error, response) => {
-				const alive = !error && response.statusCode === 200
+				const alive = !error && response.statusCode < 400
 				resolve({ ...engine, alive })
 			})
 		})

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -336,6 +336,7 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 	 * @param okToDestroyStuff Whether it is OK to do things that affects playout visibly
 	 */
 	async makeReady (okToDestroyStuff?: boolean, activeRundownPlaylistId?: string): Promise<void> {
+		const previousPlaylistId = this._vizmseManager?.activeRundownPlaylistId
 		if (this._vizmseManager) {
 			const preload = !!(this._initOptions && this._initOptions.onlyPreloadActiveRundown)
 			await this._vizmseManager.activate(activeRundownPlaylistId, preload)
@@ -348,7 +349,8 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 			if (this._vizmseManager) {
 				if (
 					this._initOptions &&
-					this._initOptions.clearAllOnMakeReady
+					this._initOptions.clearAllOnMakeReady &&
+					activeRundownPlaylistId !== previousPlaylistId
 				) {
 					if (this._initOptions.clearAllTemplateName) {
 						await this._vizmseManager.clearAll({
@@ -783,6 +785,10 @@ class VizMSEManager extends EventEmitter {
 	private _cacheInternalElementsSentLoaded: {[hash: string]: true} = {}
 	private _activeRundownPlaylistId: string | undefined
 	private _preloadedRundownPlaylistId: string | undefined
+
+	public get activeRundownPlaylistId () {
+		return this._activeRundownPlaylistId
+	}
 
 	constructor (
 		private _parentVizMSEDevice: VizMSEDevice,

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -335,15 +335,10 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 	 * Prepares the physical device for playout.
 	 * @param okToDestroyStuff Whether it is OK to do things that affects playout visibly
 	 */
-	async makeReady (okToDestroyStuff?: boolean, activeRundownId?: string): Promise<void> {
+	async makeReady (okToDestroyStuff?: boolean, activeRundownPlaylistId?: string): Promise<void> {
 		if (this._vizmseManager) {
-			this._vizmseManager.activeRundownId = (
-				(this._initOptions && this._initOptions.onlyPreloadActiveRundown) ?
-				activeRundownId :
-				undefined
-			)
-			await this._vizmseManager.activate()
-
+			const preload = !!(this._initOptions && this._initOptions.onlyPreloadActiveRundown)
+			await this._vizmseManager.activate(activeRundownPlaylistId, preload)
 		} else throw new Error(`Unable to activate vizMSE, not initialized yet!`)
 
 		if (okToDestroyStuff) {
@@ -769,7 +764,6 @@ class VizMSEManager extends EventEmitter {
 	public initialized: boolean = false
 	public notLoadedCount: number = 0
 	public loadingCount: number = 0
-	public activeRundownId: string | undefined
 
 	private _rundown: VRundown | undefined
 	private _elementCache: {[hash: string]: CachedVElement } = {}
@@ -787,6 +781,8 @@ class VizMSEManager extends EventEmitter {
 	} = {}
 	public ignoreAllWaits: boolean = false // Only to be used in tests
 	private _cacheInternalElementsSentLoaded: {[hash: string]: true} = {}
+	private _activeRundownPlaylistId: string | undefined
+	private _preloadedRundownPlaylistId: string | undefined
 
 	constructor (
 		private _parentVizMSEDevice: VizMSEDevice,
@@ -902,22 +898,28 @@ class VizMSEManager extends EventEmitter {
 	 * This causes the MSE rundown to activate, which must be done before using it.
 	 * Doing this will make MSE start loading things onto the vizEngine etc.
 	 */
-	public async activate (): Promise<void> {
-		this._triggerCommandSent()
-		const rundown = await this._getRundown()
+	public async activate (rundownPlaylistId: string | undefined, preload: boolean): Promise<void> {
+		this._preloadedRundownPlaylistId = preload ? rundownPlaylistId : undefined
+		let loadTwice = false
+		if (!rundownPlaylistId || this._activeRundownPlaylistId !== rundownPlaylistId) {
+			this._triggerCommandSent()
+			const rundown = await this._getRundown()
 
-		// clear any existing elements from the existing rundown
-		try {
-			await rundown.purge()
-		} catch (error) {
-			this.emit('error', error)
+			// clear any existing elements from the existing rundown
+			try {
+				await rundown.purge()
+			} catch (error) {
+				this.emit('error', error)
+			}
+			this._clearCache()
+			this._clearMediaObjects()
+			loadTwice = true
 		}
-		this._clearCache()
-		this._clearMediaObjects()
 
 		this._triggerCommandSent()
-		await this._triggerLoadAllElements(true)
+		await this._triggerLoadAllElements(loadTwice)
 		this._triggerCommandSent()
+		this._activeRundownPlaylistId = rundownPlaylistId
 		this._hasActiveRundown = true
 	}
 	/**
@@ -934,6 +936,7 @@ class VizMSEManager extends EventEmitter {
 	}
 	public standDownActiveRundown (): void {
 		this._hasActiveRundown = false
+		this._activeRundownPlaylistId = undefined
 	}
 	private _clearMediaObjects (): void {
 		this.emit('clearMediaObjects', this._parentVizMSEDevice.deviceId)
@@ -1282,8 +1285,8 @@ class VizMSEManager extends EventEmitter {
 			const templateName = typeof expectedPlayoutItem.templateName as string | number | undefined
 			return (
 				(
-					!this.activeRundownId ||
-					this.activeRundownId === expectedPlayoutItem.playlistId
+					!this._preloadedRundownPlaylistId ||
+					this._preloadedRundownPlaylistId === expectedPlayoutItem.playlistId
 				) &&
 				typeof templateName !== 'undefined'
 			)
@@ -1348,7 +1351,7 @@ class VizMSEManager extends EventEmitter {
 		}))
 		if (this._rundown) {
 
-			this.emit('debug', `Updating status of elements starting, activeRundownId="${this.activeRundownId}", elementsToLoad.length=${elementsToLoad.length} (${_.keys(hashesAndItems).length})`)
+			this.emit('debug', `Updating status of elements starting, activeRundownId="${this._preloadedRundownPlaylistId}", elementsToLoad.length=${elementsToLoad.length} (${_.keys(hashesAndItems).length})`)
 
 			const rundown = await this._getRundown()
 

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -1396,7 +1396,7 @@ class VizMSEManager extends EventEmitter {
 							element: newEl,
 							isLoaded: this._isElementLoaded(newEl),
 							isLoading: this._isElementLoading(newEl),
-							wasLoaded: cachedEl.wasLoaded
+							wasLoaded: cachedEl?.wasLoaded
 						}
 						this._elementsLoaded[e.hash] = newLoadedEl
 						this.emit('debug', `Element ${elementRef}: ${JSON.stringify(newEl)}`)

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -1517,7 +1517,7 @@ class VizMSEManager extends EventEmitter {
 		const enginesDisconnected: string[] = []
 		statuses.forEach((status) => {
 			if (!status.alive) {
-				enginesDisconnected.push(`${status.name} (${status.host})`)
+				enginesDisconnected.push(`${status.channel || status.name} (${status.host})`)
 			}
 		})
 		if (!_.isEqual(enginesDisconnected, this.enginesDisconnected)) {

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -916,7 +916,9 @@ class VizMSEManager extends EventEmitter {
 
 			// clear any existing elements from the existing rundown
 			try {
-				await rundown.purge()
+				this.emit('debug', `VizMSE: purging rundown`)
+				const elementsToKeep = (this._expectedPlayoutItems.filter((item) => !item.playlistId && _.isNumber(item.templateName)) as { templateName: number, channelName?: string }[]).map((item => ({ vcpid: item.templateName, channelName: item.channelName })))
+				await rundown.purge(elementsToKeep)
 			} catch (error) {
 				this.emit('error', error)
 			}
@@ -1300,6 +1302,7 @@ class VizMSEManager extends EventEmitter {
 			return (
 				(
 					!this._preloadedRundownPlaylistId ||
+					!expectedPlayoutItem.playlistId ||
 					this._preloadedRundownPlaylistId === expectedPlayoutItem.playlistId
 				) &&
 				typeof templateName !== 'undefined'

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -782,6 +782,7 @@ class VizMSEManager extends EventEmitter {
 	private _getRundownPromise?: Promise<VRundown>
 	private _mseConnected: boolean = false
 	private _msePingConnected: boolean = false
+	private _loadingAllElements: boolean = false
 	private _waitWithLayers: {
 		[portId: string]: Function[]
 	} = {}
@@ -916,9 +917,12 @@ class VizMSEManager extends EventEmitter {
 		this._clearMediaObjects()
 
 		this._triggerCommandSent()
-		await this._triggerLoadAllElements(true)
-		this._triggerCommandSent()
-		this._hasActiveRundown = true
+		this._triggerLoadAllElements(true).then(() => {
+			this._triggerCommandSent()
+			this._hasActiveRundown = true
+		}).catch((e) => {
+			this.emit('error', e)
+		})
 	}
 	/**
 	 * Deactivate the MSE rundown.
@@ -1411,27 +1415,33 @@ class VizMSEManager extends EventEmitter {
 	 * Trigger a load of all elements that are not yet loaded onto the vizEngine.
 	 */
 	private async _triggerLoadAllElements (loadTwice: boolean = false): Promise<void> {
-		const rundown = await this._getRundown()
+		if (this._loadingAllElements) {
+			this.emit('warning', '_triggerLoadAllElements already running')
+			return
+		}
+		this._loadingAllElements = true
+		try {
+			const rundown = await this._getRundown()
 
-		this.emit('debug', '_triggerLoadAllElements starting')
-		// First, update the loading-status of all elements:
-		await this.updateElementsLoadedStatus(true)
+			this.emit('debug', '_triggerLoadAllElements starting')
+			// First, update the loading-status of all elements:
+			await this.updateElementsLoadedStatus(true)
 
-		// if (this._initializeRundownOnLoadAll) {
+			// if (this._initializeRundownOnLoadAll) {
 
-		// Then, load all elements that needs loading:
-		const loadAllElementsThatNeedsLoading = async () => {
-			this._triggerCommandSent()
-			try {
-				this.emit('debug', 'rundown.activate triggered')
-				await rundown.activate() // Our theory: an extra initialization of the rundown playlist loads all internal elements
-			} catch (error) {
-				this.emit('warning', `Ignored error for rundown.activate(): ${error}`)
-			}
-			this._triggerCommandSent()
-			await this._wait(1000)
-			this._triggerCommandSent()
-			await Promise.all(
+			// Then, load all elements that needs loading:
+			const loadAllElementsThatNeedsLoading = async () => {
+				this._triggerCommandSent()
+				try {
+					this.emit('debug', 'rundown.activate triggered')
+					await rundown.activate() // Our theory: an extra initialization of the rundown playlist loads all internal elements
+				} catch (error) {
+					this.emit('warning', `Ignored error for rundown.activate(): ${error}`)
+				}
+				this._triggerCommandSent()
+				await this._wait(1000)
+				this._triggerCommandSent()
+				await Promise.all(
 				_.map(this._elementsLoaded, async (e) => {
 					if (this._isInternalElement(e.element)) {
 						// Not loading individual internal elements, since a show.initialization loads them good enough
@@ -1452,19 +1462,24 @@ class VizMSEManager extends EventEmitter {
 					}
 				})
 			)
-		}
+			}
 
-		// He's making a list:
-		await loadAllElementsThatNeedsLoading()
-		await this._wait(2000)
-		if (loadTwice) {
-			// He's checking it twice:
-			await this.updateElementsLoadedStatus()
-			// Gonna find out what's loaded and nice:
+			// He's making a list:
 			await loadAllElementsThatNeedsLoading()
-		}
+			await this._wait(2000)
+			if (loadTwice) {
+				// He's checking it twice:
+				await this.updateElementsLoadedStatus()
+				// Gonna find out what's loaded and nice:
+				await loadAllElementsThatNeedsLoading()
+			}
 
-		this.emit('debug', '_triggerLoadAllElements done')
+			this.emit('debug', '_triggerLoadAllElements done')
+		} catch (e) {
+			throw e
+		} finally {
+			this._loadingAllElements = false
+		}
 	}
 	private _monitorConnection (): void {
 		// (the ping will throuw on a timeout if ping doesn't return in time)

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -1268,10 +1268,10 @@ class VizMSEManager extends EventEmitter {
 				return internalEl
 			}
 		} catch (e) {
-			if (e.toString().match(/already exist/i)) { // "An internal graphics element with name 'xxxxxxxxxxxxxxx' already exists."
+			if (e.toString().match(/already exist/i)) { // "An internal/external graphics element with name 'xxxxxxxxxxxxxxx' already exists."
 				// If the object already exists, it's not an error, fetch and use the element instead
 
-				const element = await rundown.getElement(cmd.templateInstance)
+				const element = _.isNumber(cmd.templateName) ? await rundown.getElement(cmd.templateName) : await rundown.getElement(cmd.templateInstance)
 
 				this._cacheElement(elementHash, element)
 				return element

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -237,6 +237,9 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 	}
 	public connectionChanged (connected?: boolean) {
 		if (connected === true || connected === false) this._vizMSEConnected = connected
+		if (connected === false) {
+			this.emit('clearMediaObjects', this.deviceId)
+		}
 		this.emit('connectionChanged', this.getStatus())
 	}
 	/**
@@ -401,7 +404,6 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 		if (!this._vizMSEConnected) {
 			statusCode = StatusCode.BAD
 			messages.push('Not connected')
-			this.emit('clearMediaObjects', this.deviceId)
 		} else if (this._vizmseManager) {
 			if (this._vizmseManager.notLoadedCount > 0 || this._vizmseManager.loadingCount > 0) {
 				statusCode = StatusCode.WARNING_MINOR
@@ -794,6 +796,7 @@ class VizMSEManager extends EventEmitter {
 	private _terminated: boolean = false
 	private _activeRundownPlaylistId: string | undefined
 	private _preloadedRundownPlaylistId: string | undefined
+	private _updateAfterReconnect: boolean = false
 
 	public get activeRundownPlaylistId () {
 		return this._activeRundownPlaylistId
@@ -1395,7 +1398,7 @@ class VizMSEManager extends EventEmitter {
 							isLoading: this._isElementLoading(newEl)
 						}
 						this.emit('debug', `Element ${elementRef}: ${JSON.stringify(newEl)}`)
-						if (this._isExternalElement(newEl) && cachedEl?.isLoaded !== this._elementsLoaded[e.hash].isLoaded) {
+						if (this._isExternalElement(newEl) && (this._updateAfterReconnect || cachedEl?.isLoaded !== this._elementsLoaded[e.hash].isLoaded)) {
 							if (this._elementsLoaded[e.hash].isLoaded) {
 								const mediaObject: MediaObject = {
 									_id: e.hash,
@@ -1419,7 +1422,7 @@ class VizMSEManager extends EventEmitter {
 					}
 				})
 			)
-
+			this._updateAfterReconnect = false
 			this.emit('debug', `Updating status of elements done, this._elementsLoaded.length=${_.keys(this._elementsLoaded).length}`)
 
 		} else {
@@ -1736,6 +1739,9 @@ class VizMSEManager extends EventEmitter {
 	private mseConnectionChanged (connected: boolean) {
 		if (connected !== this._mseConnected) {
 			this._mseConnected = connected
+			if (connected) {
+				this._updateAfterReconnect = true
+			}
 			this.onConnectionChanged()
 		}
 	}

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -36,15 +36,14 @@ import {
 	VRundown,
 	InternalElement,
 	ExternalElement,
-	VElement,
-	VProfile,
-	VizEngine
+	VElement
 } from 'v-connection'
 
 import { DoOnTime, SendMode } from '../doOnTime'
 
 import * as crypto from 'crypto'
 import * as net from 'net'
+import * as request from 'request'
 import { MediaObject } from '../types/src/mediaObject'
 
 /** The ideal time to prepare elements before going on air */
@@ -73,6 +72,8 @@ export interface DeviceOptionsVizMSEInternal extends DeviceOptionsVizMSE {
 	)
 }
 export type CommandReceiver = (time: number, cmd: VizMSECommand, context: string, timelineObjId: string) => Promise<any>
+export type Engine = {name: string, channel?: string, host: string, port: number}
+type EngineStatus = Engine & { alive: boolean }
 /**
  * This class is used to interface with a vizRT Media Sequence Editor, through the v-connection library.
  * It features playing both "internal" graphics element and vizPilot elements.
@@ -125,6 +126,7 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 			this._vizMSE,
 			this._initOptions.preloadAllElements,
 			this._initOptions.autoLoadInternalElements,
+			this._initOptions.engineRestPort,
 			initOptions.showID,
 			initOptions.profile,
 			initOptions.playlistID
@@ -402,15 +404,17 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 		if (!this._vizMSEConnected) {
 			statusCode = StatusCode.BAD
 			messages.push('Not connected')
-		} else if (
-			this._vizmseManager &&
-			(
-				this._vizmseManager.notLoadedCount > 0 ||
-				this._vizmseManager.loadingCount > 0
-			)
-		) {
-			statusCode = StatusCode.WARNING_MINOR
-			messages.push(`Got ${this._vizmseManager.notLoadedCount} elements not yet loaded to the Viz Engine (${this._vizmseManager.loadingCount} are currently loading)`)
+		} else if (this._vizmseManager) {
+			if (this._vizmseManager.notLoadedCount > 0 || this._vizmseManager.loadingCount > 0) {
+				statusCode = StatusCode.WARNING_MINOR
+				messages.push(`Got ${this._vizmseManager.notLoadedCount} elements not yet loaded to the Viz Engine (${this._vizmseManager.loadingCount} are currently loading)`)
+			}
+			if (this._vizmseManager.enginesDisconnected.length) {
+				statusCode = StatusCode.BAD
+				this._vizmseManager.enginesDisconnected.forEach(engine => {
+					messages.push(`Viz Engine ${engine} disconnected`)
+				})
+			}
 		}
 
 		return {
@@ -769,6 +773,7 @@ class VizMSEManager extends EventEmitter {
 	public initialized: boolean = false
 	public notLoadedCount: number = 0
 	public loadingCount: number = 0
+	public enginesDisconnected: Array<string> = []
 	public activeRundownId: string | undefined
 
 	private _rundown: VRundown | undefined
@@ -787,12 +792,14 @@ class VizMSEManager extends EventEmitter {
 	} = {}
 	public ignoreAllWaits: boolean = false // Only to be used in tests
 	private _cacheInternalElementsSentLoaded: {[hash: string]: true} = {}
+	private _terminated: boolean = false
 
 	constructor (
 		private _parentVizMSEDevice: VizMSEDevice,
 		private _vizMSE: MSE,
 		public preloadAllElements: boolean = false,
 		public autoLoadInternalElements: boolean = false,
+		public engineRestPort: number | undefined,
 		private _showID: string,
 		private _profile: string,
 		private _playlistID?: string
@@ -835,10 +842,7 @@ class VizMSEManager extends EventEmitter {
 				})
 			}, MONITOR_INTERVAL)
 
-			if (this._monitorMSEConnection) {
-				clearInterval(this._monitorMSEConnection)
-			}
-			this._monitorMSEConnection = setInterval(() => this._monitorConnection(), MONITOR_INTERVAL)
+			this._setMonitorConnectionTimeout()
 
 			this.initialized = true
 		}
@@ -849,11 +853,12 @@ class VizMSEManager extends EventEmitter {
 	 * Close connections and die
 	 */
 	public async terminate () {
+		this._terminated = true
 		if (this._monitorAndLoadElementsInterval) {
 			clearInterval(this._monitorAndLoadElementsInterval)
 		}
 		if (this._monitorMSEConnection) {
-			clearInterval(this._monitorMSEConnection)
+			clearTimeout(this._monitorMSEConnection)
 		}
 		if (this._vizMSE) {
 			await this._vizMSE.close()
@@ -1073,9 +1078,8 @@ class VizMSEManager extends EventEmitter {
 	 */
 	public async clearEngines (cmd: VizMSECommandClearAllEngines): Promise<void> {
 		try {
-			const profile = await this._vizMSE.getProfile(this._profile)
-			const engines = await this._vizMSE.getEngines()
-			const enginesToClear = this._prepareEnginesToClear(profile, engines, cmd.channels)
+			const engines = await this._getEngines()
+			const enginesToClear = this._filterEnginesToClear(engines, cmd.channels)
 			enginesToClear.forEach(engine => {
 				const sender = new VizEngineTcpSender(engine.port, engine.host)
 				sender.on('warning', w => this.emit('warning', `clearEngines: ${w}`))
@@ -1086,8 +1090,10 @@ class VizMSEManager extends EventEmitter {
 			this.emit('warning', `Sending Clear-all command failed ${e}`)
 		}
 	}
-	private _prepareEnginesToClear (profile: VProfile, engines: VizEngine[], channels: string[] | 'all'): Array<{host: string, port: number}> {
-		const enginesToClear: Array<{host: string, port: number}> = []
+	private async _getEngines (): Promise<Engine[]> {
+		const profile = await this._vizMSE.getProfile(this._profile)
+		const engines = await this._vizMSE.getEngines()
+		const result: Engine[] = []
 		const outputs = new Map<string, string>() // engine name : channel name
 		_.each(profile.execution_groups, (group, groupName) => {
 			_.each(group, entry => {
@@ -1104,15 +1110,16 @@ class VizMSEManager extends EventEmitter {
 		outputEngines.forEach(engine => {
 			_.each(_.keys(engine.renderer), fullHost => {
 				const channelName = outputs.get(engine.name)
-				if (channels === 'all' || _.contains(channels, channelName)) {
-					const match = fullHost.match(/([^:]+):?(\d*)?/)
-					const port = (match && match[2]) ? parseInt(match[2], 10) : 6100
-					const host = (match && match[1]) ? match[1] : fullHost
-					enginesToClear.push({ host, port })
-				}
+				const match = fullHost.match(/([^:]+):?(\d*)?/)
+				const port = (match && match[2]) ? parseInt(match[2], 10) : 6100
+				const host = (match && match[1]) ? match[1] : fullHost
+				result.push({ name: engine.name, channel: channelName, host, port })
 			})
 		})
-		return enginesToClear
+		return result
+	}
+	private _filterEnginesToClear (engines: Engine[], channels: string[] | 'all'): Array<{host: string, port: number}> {
+		return engines.filter(engine => channels === 'all' || engine.channel && channels.includes(engine.channel))
 	}
 	/**
 	 * Load all elements: Trigger a loading of all pilot elements onto the vizEngine.
@@ -1466,24 +1473,65 @@ class VizMSEManager extends EventEmitter {
 
 		this.emit('debug', '_triggerLoadAllElements done')
 	}
+	private _setMonitorConnectionTimeout (): void {
+		if (this._monitorMSEConnection) {
+			clearTimeout(this._monitorMSEConnection)
+		}
+		if (!this._terminated) {
+			this._monitorMSEConnection = setTimeout(() => this._monitorConnection(), MONITOR_INTERVAL)
+		}
+	}
 	private _monitorConnection (): void {
 		// (the ping will throuw on a timeout if ping doesn't return in time)
 		if (this.initialized) {
 			this._vizMSE.ping()
-			.then(() => {
+			.then(async () => {
 				// ok!
 				if (!this._msePingConnected) {
 					this._msePingConnected = true
 					this.onConnectionChanged()
 				}
-			}, () => {
+				await this._monitorEngines()
+				this._setMonitorConnectionTimeout()
+			}, async () => {
 				// not ok!
 				if (this._msePingConnected) {
 					this._msePingConnected = false
 					this.onConnectionChanged()
 				}
+				await this._monitorEngines()
+				this._setMonitorConnectionTimeout()
 			})
 		}
+	}
+	private async _monitorEngines () {
+		if (!this.engineRestPort) {
+			return
+		}
+		const engines = await this._getEngines()
+		const ps: Promise<EngineStatus>[] = []
+		engines.forEach(engine => {
+			return ps.push(this._pingEngine(engine))
+		})
+		const statuses = await Promise.all(ps)
+		const enginesDisconnected: string[] = []
+		statuses.forEach((status) => {
+			if (!status.alive) {
+				enginesDisconnected.push(`${status.name} (${status.host})`)
+			}
+		})
+		if (!_.isEqual(enginesDisconnected, this.enginesDisconnected)) {
+			this.enginesDisconnected = enginesDisconnected
+			this.onConnectionChanged()
+		}
+	}
+	private async _pingEngine (engine: Engine): Promise<EngineStatus> {
+		return new Promise((resolve, _reject) => {
+			request.get(`http://${engine.host}:${this.engineRestPort}/#/status`, { timeout: 2000 }, (error, response) => {
+				const alive = !error && response.statusCode === 200
+				resolve({ ...engine, alive })
+			})
+		})
 	}
 	/** Monitor loading status of expected elements */
 	private async _monitorLoadedElements (): Promise<void> {

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -931,7 +931,7 @@ class VizMSEManager extends EventEmitter {
 		}
 
 		this._triggerCommandSent()
-		this._triggerLoadAllElements(true).then(() => {
+		this._triggerLoadAllElements(loadTwice).then(() => {
 			this._triggerCommandSent()
 			this._activeRundownPlaylistId = rundownPlaylistId
 			this._hasActiveRundown = true
@@ -1410,7 +1410,7 @@ class VizMSEManager extends EventEmitter {
 									_rev: ''
 								}
 								this.emit('updateMediaObject', e.hash, mediaObject)
-							} else if (!cachedEl) {
+							} else {
 								this.emit('updateMediaObject', e.hash, null)
 							}
 						}

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -783,7 +783,7 @@ class VizMSEManager extends EventEmitter {
 	private _monitorMSEConnection?: NodeJS.Timer
 	private _lastTimeCommandSent: number = 0
 	private _hasActiveRundown: boolean = false
-	private _elementsLoaded: {[hash: string]: { element: VElement, isLoaded: boolean, isLoading: boolean}} = {}
+	private _elementsLoaded: {[hash: string]: { element: VElement, isLoaded: boolean, isLoading: boolean, wasLoaded?: boolean }} = {}
 	private _getRundownPromise?: Promise<VRundown>
 	private _mseConnected: boolean = false
 	private _msePingConnected: boolean = false
@@ -1392,29 +1392,42 @@ class VizMSEManager extends EventEmitter {
 						// Update cached status of the element:
 						const newEl = await rundown.getElement(elementRef)
 
-						this._elementsLoaded[e.hash] = {
+						const newLoadedEl = {
 							element: newEl,
 							isLoaded: this._isElementLoaded(newEl),
-							isLoading: this._isElementLoading(newEl)
+							isLoading: this._isElementLoading(newEl),
+							wasLoaded: cachedEl.wasLoaded
 						}
+						this._elementsLoaded[e.hash] = newLoadedEl
 						this.emit('debug', `Element ${elementRef}: ${JSON.stringify(newEl)}`)
-						if (this._isExternalElement(newEl) && (this._updateAfterReconnect || cachedEl?.isLoaded !== this._elementsLoaded[e.hash].isLoaded)) {
-							if (this._elementsLoaded[e.hash].isLoaded) {
-								const mediaObject: MediaObject = {
-									_id: e.hash,
-									mediaId: 'PILOT_' + e.item.templateName.toString().toUpperCase(),
-									mediaPath: e.item.templateInstance,
-									mediaSize: 0,
-									mediaTime: 0,
-									thumbSize: 0,
-									thumbTime: 0,
-									cinf: '',
-									tinf: '',
-									_rev: ''
+						if (this._isExternalElement(newEl)) {
+							if (this._updateAfterReconnect || cachedEl?.isLoaded !== newLoadedEl.isLoaded) {
+								if (cachedEl?.isLoaded && !newLoadedEl.isLoaded) {
+									newLoadedEl.wasLoaded = true
+								} else if (!cachedEl?.isLoaded && newLoadedEl.isLoaded) {
+									newLoadedEl.wasLoaded = false
 								}
-								this.emit('updateMediaObject', e.hash, mediaObject)
-							} else {
-								this.emit('updateMediaObject', e.hash, null)
+								if (newLoadedEl.isLoaded) {
+									const mediaObject: MediaObject = {
+										_id: e.hash,
+										mediaId: 'PILOT_' + e.item.templateName.toString().toUpperCase(),
+										mediaPath: e.item.templateInstance,
+										mediaSize: 0,
+										mediaTime: 0,
+										thumbSize: 0,
+										thumbTime: 0,
+										cinf: '',
+										tinf: '',
+										_rev: ''
+									}
+									this.emit('updateMediaObject', e.hash, mediaObject)
+								} else {
+									this.emit('updateMediaObject', e.hash, null)
+								}
+							}
+							if (newLoadedEl.wasLoaded && !newLoadedEl.isLoaded && !newLoadedEl.isLoading) {
+								this.emit('debug', `Element "${this._getElementReference(newEl)}" went from loaded to not loaded, initializing`)
+								await rundown.initialize(this._getElementReference(newEl))
 							}
 						}
 					} catch (e) {

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -133,8 +133,8 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 		)
 
 		this._vizmseManager.on('connectionChanged', (connected) => this.connectionChanged(connected))
-		this._vizmseManager.on('updateMediaObject', (collectionId: string, docId: string, doc: MediaObject | null) => this.emit('updateMediaObject', collectionId, docId, doc))
-		this._vizmseManager.on('clearMediaObjects', (collectionId: string) => this.emit('clearMediaObjects', collectionId))
+		this._vizmseManager.on('updateMediaObject', (docId: string, doc: MediaObject | null) => this.emit('updateMediaObject', this.deviceId, docId, doc))
+		this._vizmseManager.on('clearMediaObjects', () => this.emit('clearMediaObjects', this.deviceId))
 
 		this._vizmseManager.on('info', str => this.emit('info', 'VizMSE: ' + str))
 		this._vizmseManager.on('warning', str => this.emit('warning', 'VizMSE' + str))
@@ -404,6 +404,7 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 		if (!this._vizMSEConnected) {
 			statusCode = StatusCode.BAD
 			messages.push('Not connected')
+			this.emit('clearMediaObjects', this.deviceId)
 		} else if (this._vizmseManager) {
 			if (this._vizmseManager.notLoadedCount > 0 || this._vizmseManager.loadingCount > 0) {
 				statusCode = StatusCode.WARNING_MINOR
@@ -941,7 +942,7 @@ class VizMSEManager extends EventEmitter {
 		this._hasActiveRundown = false
 	}
 	private _clearMediaObjects (): void {
-		this.emit('clearMediaObjects', this._parentVizMSEDevice.deviceId)
+		this.emit('clearMediaObjects')
 	}
 	/**
 	 * Prepare an element
@@ -1396,9 +1397,9 @@ class VizMSEManager extends EventEmitter {
 										tinf: '',
 										_rev: ''
 									}
-									this.emit('updateMediaObject', this._parentVizMSEDevice.deviceId, e.hash, mediaObject)
+									this.emit('updateMediaObject', e.hash, mediaObject)
 								} else if (!cachedEl) {
-									this.emit('updateMediaObject', this._parentVizMSEDevice.deviceId, e.hash, null)
+									this.emit('updateMediaObject', e.hash, null)
 								}
 							}
 						} catch (e) {

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -834,6 +834,7 @@ class VizMSEManager extends EventEmitter {
 
 				if (!rundown) throw new Error(`VizMSEManager: Unable to create rundown!`)
 			} catch (e) {
+				this.emit('debug', `VizMSE: initializeRundownInner ${e}`)
 				setTimeout(() => initializeRundownInner(), INIT_RETRY_INTERVAL)
 				return
 			}
@@ -1565,9 +1566,13 @@ class VizMSEManager extends EventEmitter {
 		}
 	}
 	private async _pingEngine (engine: Engine): Promise<EngineStatus> {
-		return new Promise((resolve, _reject) => {
-			request.get(`http://${engine.host}:${this.engineRestPort}/#/status`, { timeout: 2000 }, (error, response) => {
-				const alive = !error && response.statusCode < 400
+		return new Promise((resolve) => {
+			const url = `http://${engine.host}:${this.engineRestPort}/#/status`
+			request.get(url, { timeout: 2000 }, (error, response: request.Response | undefined) => {
+				const alive = !error && response !== undefined && response?.statusCode < 400
+				if (!alive) {
+					this.emit('debug', `VizMSE: _pingEngine at "${url}", error ${error}, code ${response?.statusCode}`)
+				}
 				resolve({ ...engine, alive })
 			})
 		})

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -125,7 +125,7 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 			this,
 			this._vizMSE,
 			this._initOptions.preloadAllElements,
-			this._initOptions.onlyPreloadActiveRundown,
+			this._initOptions.onlyPreloadActivePlaylist,
 			this._initOptions.autoLoadInternalElements,
 			this._initOptions.engineRestPort,
 			initOptions.showID,
@@ -774,7 +774,7 @@ class VizMSEManager extends EventEmitter {
 	public notLoadedCount: number = 0
 	public loadingCount: number = 0
 	public enginesDisconnected: Array<string> = []
-	public activeRundownId: string | undefined
+	public activePlaylistId: string | undefined
 
 	private _rundown: VRundown | undefined
 	private _elementCache: {[hash: string]: CachedVElement } = {}
@@ -806,7 +806,7 @@ class VizMSEManager extends EventEmitter {
 		private _parentVizMSEDevice: VizMSEDevice,
 		private _vizMSE: MSE,
 		public preloadAllElements: boolean = false,
-		public onlyPreloadActiveRundown: boolean = false,
+		public onlyPreloadActivePlaylist: boolean = false,
 		public autoLoadInternalElements: boolean = false,
 		public engineRestPort: number | undefined,
 		private _showID: string,
@@ -822,7 +822,7 @@ class VizMSEManager extends EventEmitter {
 	public async initializeRundown (activeRundownPlaylistId: string | undefined): Promise<void> {
 		this._vizMSE.on('connected', () => this.mseConnectionChanged(true))
 		this._vizMSE.on('disconnected', () => this.mseConnectionChanged(false))
-		this._preloadedRundownPlaylistId = this.onlyPreloadActiveRundown ? activeRundownPlaylistId : undefined
+		this._preloadedRundownPlaylistId = this.onlyPreloadActivePlaylist ? activeRundownPlaylistId : undefined
 
 		if (activeRundownPlaylistId) {
 			this.emit('debug', `VizMSE: already active playlist: ${this._preloadedRundownPlaylistId}`)
@@ -914,7 +914,7 @@ class VizMSEManager extends EventEmitter {
 	 * Doing this will make MSE start loading things onto the vizEngine etc.
 	 */
 	public async activate (rundownPlaylistId: string | undefined): Promise<void> {
-		this._preloadedRundownPlaylistId = this.onlyPreloadActiveRundown ? rundownPlaylistId : undefined
+		this._preloadedRundownPlaylistId = this.onlyPreloadActivePlaylist ? rundownPlaylistId : undefined
 		let loadTwice = false
 		if (!rundownPlaylistId || this._activeRundownPlaylistId !== rundownPlaylistId) {
 			this._triggerCommandSent()
@@ -1374,7 +1374,7 @@ class VizMSEManager extends EventEmitter {
 		}))
 		if (this._rundown) {
 
-			this.emit('debug', `Updating status of elements starting, activeRundownId="${this._preloadedRundownPlaylistId}", elementsToLoad.length=${elementsToLoad.length} (${_.keys(hashesAndItems).length})`)
+			this.emit('debug', `Updating status of elements starting, activePlaylistId="${this._preloadedRundownPlaylistId}", elementsToLoad.length=${elementsToLoad.length} (${_.keys(hashesAndItems).length})`)
 
 			const rundown = await this._getRundown()
 

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -17,7 +17,6 @@ import {
 	TimelineObjVIZMSEElementInternal,
 	TimelineContentTypeVizMSE,
 	TimelineObjVIZMSEElementPilot,
-	ExpectedPlayoutItemContent,
 	VIZMSEPlayoutItemContent,
 	DeviceOptionsVizMSE,
 	TimelineObjVIZMSEAny,
@@ -45,6 +44,7 @@ import * as crypto from 'crypto'
 import * as net from 'net'
 import * as request from 'request'
 import { MediaObject } from '../types/src/mediaObject'
+import { ExpectedPlayoutItem } from '../expectedPlayoutItems'
 
 /** The ideal time to prepare elements before going on air */
 const IDEAL_PREPARE_TIME = 1000
@@ -224,7 +224,7 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState> implements IDevic
 	get supportsExpectedPlayoutItems (): boolean {
 		return true
 	}
-	public handleExpectedPlayoutItems (expectedPlayoutItems: Array<ExpectedPlayoutItemContent>): void {
+	public handleExpectedPlayoutItems (expectedPlayoutItems: Array<ExpectedPlayoutItem>): void {
 		this.emit('debug', 'VIZDEBUG: handleExpectedPlayoutItems called')
 		if (this._vizmseManager) {
 			this.emit('debug', 'VIZDEBUG: manager exists')
@@ -778,7 +778,7 @@ class VizMSEManager extends EventEmitter {
 
 	private _rundown: VRundown | undefined
 	private _elementCache: {[hash: string]: CachedVElement } = {}
-	private _expectedPlayoutItems: Array<ExpectedPlayoutItemContent> = []
+	private _expectedPlayoutItems: Array<ExpectedPlayoutItem> = []
 	private _monitorAndLoadElementsTimeout?: NodeJS.Timer
 	private _monitorMSEConnectionTimeout?: NodeJS.Timer
 	private _lastTimeCommandSent: number = 0
@@ -868,7 +868,7 @@ class VizMSEManager extends EventEmitter {
 	 * Set the collection of expectedPlayoutItems.
 	 * These will be monitored and can be triggered to pre-load.
 	 */
-	public setExpectedPlayoutItems (expectedPlayoutItems: Array<ExpectedPlayoutItemContent>) {
+	public setExpectedPlayoutItems (expectedPlayoutItems: Array<ExpectedPlayoutItem>) {
 		this.emit('debug', 'VIZDEBUG: setExpectedPlayoutItems called')
 		if (this.preloadAllElements) {
 			this.emit('debug', 'VIZDEBUG: preload elements allowed')

--- a/src/devices/vizMSE.ts
+++ b/src/devices/vizMSE.ts
@@ -1366,44 +1366,41 @@ class VizMSEManager extends EventEmitter {
 				_.map(elementsToLoad, async (e) => {
 
 					const cachedEl = this._elementsLoaded[e.hash]
+					try {
+						const elementRef = await this._checkPrepareElement(e.item)
 
-					if (!cachedEl || !cachedEl.isLoaded) {
-						try {
-							const elementRef = await this._checkPrepareElement(e.item)
+						this.emit('debug', `Updating status of element ${elementRef}`)
 
-							this.emit('debug', `Updating status of element ${elementRef}`)
+						// Update cached status of the element:
+						const newEl = await rundown.getElement(elementRef)
 
-							// Update cached status of the element:
-							const newEl = await rundown.getElement(elementRef)
-
-							this._elementsLoaded[e.hash] = {
-								element: newEl,
-								isLoaded: this._isElementLoaded(newEl),
-								isLoading: this._isElementLoading(newEl)
-							}
-							this.emit('debug', `Element ${elementRef}: ${JSON.stringify(newEl)}`)
-							if (this._isExternalElement(newEl)) {
-								if (this._elementsLoaded[e.hash].isLoaded) {
-									const mediaObject: MediaObject = {
-										_id: e.hash,
-										mediaId: 'PILOT_' + e.item.templateName.toString().toUpperCase(),
-										mediaPath: e.item.templateInstance,
-										mediaSize: 0,
-										mediaTime: 0,
-										thumbSize: 0,
-										thumbTime: 0,
-										cinf: '',
-										tinf: '',
-										_rev: ''
-									}
-									this.emit('updateMediaObject', this._parentVizMSEDevice.deviceId, e.hash, mediaObject)
-								} else if (!cachedEl) {
-									this.emit('updateMediaObject', this._parentVizMSEDevice.deviceId, e.hash, null)
-								}
-							}
-						} catch (e) {
-							this.emit('error', `Error in updateElementsLoadedStatus: ${e.toString()}`)
+						this._elementsLoaded[e.hash] = {
+							element: newEl,
+							isLoaded: this._isElementLoaded(newEl),
+							isLoading: this._isElementLoading(newEl)
 						}
+						this.emit('debug', `Element ${elementRef}: ${JSON.stringify(newEl)}`)
+						if (this._isExternalElement(newEl) && cachedEl?.isLoaded !== this._elementsLoaded[e.hash].isLoaded) {
+							if (this._elementsLoaded[e.hash].isLoaded) {
+								const mediaObject: MediaObject = {
+									_id: e.hash,
+									mediaId: 'PILOT_' + e.item.templateName.toString().toUpperCase(),
+									mediaPath: e.item.templateInstance,
+									mediaSize: 0,
+									mediaTime: 0,
+									thumbSize: 0,
+									thumbTime: 0,
+									cinf: '',
+									tinf: '',
+									_rev: ''
+								}
+								this.emit('updateMediaObject', this._parentVizMSEDevice.deviceId, e.hash, mediaObject)
+							} else {
+								this.emit('updateMediaObject', this._parentVizMSEDevice.deviceId, e.hash, null)
+							}
+						}
+					} catch (e) {
+						this.emit('error', `Error in updateElementsLoadedStatus: ${e.toString()}`)
 					}
 				})
 			)

--- a/src/expectedPlayoutItems.ts
+++ b/src/expectedPlayoutItems.ts
@@ -1,0 +1,10 @@
+import { ExpectedPlayoutItemContent } from './types/src'
+
+export interface ExpectedPlayoutItemContentBase {
+	/** Id of the rundown the items comes from */
+	rundownId: string
+	/** Id of the rundown playlist the items comes from */
+	playlistId: string
+}
+
+export type ExpectedPlayoutItem = ExpectedPlayoutItemContent & ExpectedPlayoutItemContentBase

--- a/src/expectedPlayoutItems.ts
+++ b/src/expectedPlayoutItems.ts
@@ -5,6 +5,8 @@ export interface ExpectedPlayoutItemContentBase {
 	rundownId: string
 	/** Id of the rundown playlist the items comes from */
 	playlistId: string
+	/** Is created for studio/rundown baseline */
+	baseline?: 'rundown' | 'studio'
 }
 
 export type ExpectedPlayoutItem = ExpectedPlayoutItemContent & ExpectedPlayoutItemContentBase

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 
 export * from './conductor'
 export * from './doOnTime'
+export * from './expectedPlayoutItems'
 export { CasparCGDevice } from './devices/casparCG'
 export { HyperdeckDevice } from './devices/hyperdeck'
 export { QuantelDevice } from './devices/quantel'

--- a/src/types/src/expectedPlayoutItems.ts
+++ b/src/types/src/expectedPlayoutItems.ts
@@ -1,11 +1,3 @@
 import { VIZMSEPlayoutItemContent } from './vizMSE'
 
-export type ExpectedPlayoutItemContent = ExpectedPlayoutItemContentVizMSE
-
-export interface ExpectedPlayoutItemContentBase {
-	/** Id of the rundown the items comes from */
-	rundownId: string
-	/** Id of the rundown playlist the items comes from */
-	playlistId: string
-}
-export type ExpectedPlayoutItemContentVizMSE = ExpectedPlayoutItemContentBase & VIZMSEPlayoutItemContent
+export type ExpectedPlayoutItemContent = VIZMSEPlayoutItemContent

--- a/src/types/src/vizMSE.ts
+++ b/src/types/src/vizMSE.ts
@@ -38,7 +38,7 @@ export interface VizMSEOptions {
 	/** If true, the rundown won't be deactivated on standdown */
 	dontDeactivateOnStandDown?: boolean
 	/** If true, only elements in the currently active rundown will be loaded */
-	onlyPreloadActiveRundown?: boolean
+	onlyPreloadActivePlaylist?: boolean
 	/** List of commands to be sent to Viz Engines in order to fully clear them */
 	clearAllCommands?: string[]
 }

--- a/src/types/src/vizMSE.ts
+++ b/src/types/src/vizMSE.ts
@@ -11,6 +11,8 @@ export interface VizMSEOptions {
 	restPort?: number
 	/** Port number to the web-sockets interface (optional) */
 	wsPort?: number
+	/** Port number to the REST interfaces of Viz Engines (optional) */
+	engineRestPort?: number
 
 	/** Identifier of the "show" to use */
 	showID: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -6250,15 +6250,15 @@ typedoc@^0.16.0:
     typedoc-default-themes "^0.7.2"
     typescript "3.7.x"
 
-typescript@3.6.x:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.5.tgz#dae20114a7b4ff4bd642db9c8c699f2953e8bbdb"
-  integrity sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==
-
 typescript@3.7.x:
   version "3.7.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+
+typescript@3.8.x:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 uglify-js@^3.1.4:
   version "3.10.4"
@@ -6374,14 +6374,14 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-"v-connection@git+https://github.com/olzzon/v-connection#vtest20210413_1":
+"v-connection@git+https://github.com/olzzon/v-connection#v20210604_1":
   version "0.0.1"
-  resolved "git+https://github.com/olzzon/v-connection#56cd7f01bab7d38786ccba900f8c63842d3b9f57"
+  resolved "git+https://github.com/olzzon/v-connection#fce072ef2e8df663cea64eefa85c3d4c5e27c329"
   dependencies:
     request "^2.88.2"
     request-promise-native "^1.0.9"
     uuid "^8.3.2"
-    ws "^7.4.2"
+    ws "^7.4.6"
     xml2js "^0.4.23"
 
 v8-to-istanbul@^5.0.1:
@@ -6585,10 +6585,10 @@ ws@^7.1.1, ws@^7.2.3:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
   integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
 
-ws@^7.4.2:
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.4.tgz#383bc9742cb202292c9077ceab6f6047b17f2d59"
-  integrity sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==
+ws@^7.4.6:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
 xdg-basedir@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -817,14 +817,6 @@ abab@^2.0.3:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
   integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
 
-accepts@^1.3.5:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
-  integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
-  dependencies:
-    mime-types "~2.1.24"
-    negotiator "0.6.2"
-
 acorn-globals@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
@@ -900,17 +892,12 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
-
 ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
-ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -924,11 +911,6 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
-
-any-promise@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
-  integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -1329,14 +1311,6 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-cache-content-type@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/cache-content-type/-/cache-content-type-1.0.1.tgz#035cde2b08ee2129f4a8315ea8f00a00dba1453c"
-  integrity sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==
-  dependencies:
-    mime-types "^2.1.18"
-    ylru "^1.2.0"
-
 cacheable-lookup@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.3.tgz#049fdc59dffdd4fc285e8f4f82936591bd59fec3"
@@ -1505,15 +1479,6 @@ cliui@^3.0.3:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
-cliui@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
-  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
-  dependencies:
-    string-width "^3.1.0"
-    strip-ansi "^5.2.0"
-    wrap-ansi "^5.1.0"
-
 cliui@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
@@ -1654,18 +1619,6 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
-
-content-disposition@~0.5.2:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.3.tgz#e130caf7e7279087c5616c2007d0485698984fbd"
-  integrity sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==
-  dependencies:
-    safe-buffer "5.1.2"
-
-content-type@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
-  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
 conventional-changelog-angular@^5.0.11:
   version "5.0.11"
@@ -1840,14 +1793,6 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
-cookies@~0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.8.0.tgz#1293ce4b391740a8406e3c9870e828c4b54f3f90"
-  integrity sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==
-  dependencies:
-    depd "~2.0.0"
-    keygrip "~1.1.0"
-
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
@@ -1968,13 +1913,6 @@ debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -2016,11 +1954,6 @@ decompress-response@^6.0.0:
   integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
   dependencies:
     mimic-response "^3.1.0"
-
-deep-equal@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
-  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -2073,21 +2006,6 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
-depd@^1.1.2, depd@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
-  integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
-
-depd@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
-  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
-
-destroy@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
-  integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
 detect-indent@^6.0.0:
   version "6.0.0"
@@ -2172,11 +2090,6 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-ee-first@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
-  integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-
 email-addresses@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/email-addresses/-/email-addresses-3.1.0.tgz#cabf7e085cbdb63008a70319a74e6136188812fb"
@@ -2199,20 +2112,10 @@ emittery@^0.7.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.7.1.tgz#c02375a927a40948c0345cc903072597f5270451"
   integrity sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==
 
-emoji-regex@^7.0.1:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
-  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
-
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-encodeurl@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
-  integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
 end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
@@ -2239,11 +2142,6 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
-
-escape-html@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
-  integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -2587,11 +2485,6 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-fresh@~0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
-  integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
-
 fs-access@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fs-access/-/fs-access-1.0.1.tgz#d6a87f262271cefebec30c553407fb995da8777a"
@@ -2934,40 +2827,10 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
-http-assert@^1.3.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/http-assert/-/http-assert-1.4.1.tgz#c5f725d677aa7e873ef736199b89686cceb37878"
-  integrity sha512-rdw7q6GTlibqVVbXr0CKelfV5iY8G2HqEUkhSk297BMbSpSL8crXC+9rjKoMcZZEsksX30le6f/4ul4E28gegw==
-  dependencies:
-    deep-equal "~1.0.1"
-    http-errors "~1.7.2"
-
 http-cache-semantics@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
-
-http-errors@^1.6.3:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.0.tgz#75d1bbe497e1044f51e4ee9e704a62f28d336507"
-  integrity sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.4"
-    setprototypeof "1.2.0"
-    statuses ">= 1.5.0 < 2"
-    toidentifier "1.0.0"
-
-http-errors@~1.7.2:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
-  integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.4"
-    setprototypeof "1.1.1"
-    statuses ">= 1.5.0 < 2"
-    toidentifier "1.0.0"
 
 http-proxy-agent@^4.0.0:
   version "4.0.1"
@@ -3097,7 +2960,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@2, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3228,11 +3091,6 @@ is-generator-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
-
-is-generator-function@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.7.tgz#d2132e529bb0000a7f80794d4bdf5cd5e5813522"
-  integrity sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==
 
 is-number@^3.0.0:
   version "3.0.0"
@@ -3902,13 +3760,6 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-keygrip@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.1.0.tgz#871b1681d5e159c62a445b0c74b615e0917e7226"
-  integrity sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==
-  dependencies:
-    tsscmp "1.0.6"
-
 keyv@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.0.3.tgz#4f3aa98de254803cafcd2896734108daa35e4254"
@@ -3944,55 +3795,6 @@ kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
-
-koa-compose@^3.0.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/koa-compose/-/koa-compose-3.2.1.tgz#a85ccb40b7d986d8e5a345b3a1ace8eabcf54de7"
-  integrity sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=
-  dependencies:
-    any-promise "^1.1.0"
-
-koa-compose@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/koa-compose/-/koa-compose-4.1.0.tgz#507306b9371901db41121c812e923d0d67d3e877"
-  integrity sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==
-
-koa-convert@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/koa-convert/-/koa-convert-1.2.0.tgz#da40875df49de0539098d1700b50820cebcd21d0"
-  integrity sha1-2kCHXfSd4FOQmNFwC1CCDOvNIdA=
-  dependencies:
-    co "^4.6.0"
-    koa-compose "^3.0.0"
-
-koa@^2.11.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/koa/-/koa-2.13.0.tgz#25217e05efd3358a7e5ddec00f0a380c9b71b501"
-  integrity sha512-i/XJVOfPw7npbMv67+bOeXr3gPqOAw6uh5wFyNs3QvJ47tUx3M3V9rIE0//WytY42MKz4l/MXKyGkQ2LQTfLUQ==
-  dependencies:
-    accepts "^1.3.5"
-    cache-content-type "^1.0.0"
-    content-disposition "~0.5.2"
-    content-type "^1.0.4"
-    cookies "~0.8.0"
-    debug "~3.1.0"
-    delegates "^1.0.0"
-    depd "^1.1.2"
-    destroy "^1.0.4"
-    encodeurl "^1.0.2"
-    escape-html "^1.0.3"
-    fresh "~0.5.2"
-    http-assert "^1.3.0"
-    http-errors "^1.6.3"
-    is-generator-function "^1.0.7"
-    koa-compose "^4.1.0"
-    koa-convert "^1.2.0"
-    on-finished "^2.3.0"
-    only "~0.0.2"
-    parseurl "^1.3.2"
-    statuses "^1.5.0"
-    type-is "^1.6.16"
-    vary "^1.1.2"
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -4198,11 +4000,6 @@ marked@^0.8.0:
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.2.tgz#4faad28d26ede351a7a1aaa5fec67915c869e355"
   integrity sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==
 
-media-typer@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
-  integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
-
 meow@^3.3.0, meow@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
@@ -4305,7 +4102,7 @@ mime-db@1.44.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
 
-mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.19, mime-types@~2.1.24:
+mime-types@^2.1.12, mime-types@~2.1.19:
   version "2.1.27"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
   integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
@@ -4460,11 +4257,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
-
-negotiator@0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
-  integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
 neo-async@^2.6.0:
   version "2.6.2"
@@ -4686,13 +4478,6 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-on-finished@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
-  integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
-  dependencies:
-    ee-first "1.1.1"
-
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -4706,11 +4491,6 @@ onetime@^5.1.0:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
-
-only@~0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/only/-/only-0.0.2.tgz#2afde84d03e50b9a8edc444e30610a70295edfb4"
-  integrity sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q=
 
 open-cli@^6.0.1:
   version "6.0.1"
@@ -4897,11 +4677,6 @@ parse5@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
   integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
-
-parseurl@^1.3.2:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
-  integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -5349,7 +5124,7 @@ request-promise-core@1.1.4:
   dependencies:
     lodash "^4.17.19"
 
-request-promise-native@^1.0.7, request-promise-native@^1.0.8:
+request-promise-native@^1.0.8, request-promise-native@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.9.tgz#e407120526a5efdc9a39b28a5679bf47b9d9dc28"
   integrity sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==
@@ -5447,15 +5222,15 @@ rsvp@^4.8.4:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
-safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
 safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -5546,16 +5321,6 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
-
-setprototypeof@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
-  integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
-
-setprototypeof@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
-  integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -5868,11 +5633,6 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.5.0 < 2", statuses@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
-  integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
-
 stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
@@ -5915,15 +5675,6 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^3.0.0, string-width@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
-  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
-  dependencies:
-    emoji-regex "^7.0.1"
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^5.1.0"
-
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
@@ -5965,13 +5716,6 @@ strip-ansi@^4.0.0:
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
-  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
-  dependencies:
-    ansi-regex "^4.1.0"
 
 strip-ansi@^6.0.0:
   version "6.0.0"
@@ -6250,11 +5994,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-toidentifier@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
-  integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
-
 token-types@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/token-types/-/token-types-2.0.0.tgz#b23618af744818299c6fbf125e0fdad98bab7e85"
@@ -6399,11 +6138,6 @@ tslint@^6.1.2:
     tslib "^1.13.0"
     tsutils "^2.29.0"
 
-tsscmp@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
-  integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
-
 tsutils@^2.29.0:
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
@@ -6476,14 +6210,6 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
-
-type-is@^1.6.16:
-  version "1.6.18"
-  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
-  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
-  dependencies:
-    media-typer "0.3.0"
-    mime-types "~2.1.24"
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
@@ -6633,7 +6359,7 @@ util-extend@^1.0.1:
   resolved "https://registry.yarnpkg.com/util-extend/-/util-extend-1.0.3.tgz#a7c216d267545169637b3b6edc6ca9119e2ff93f"
   integrity sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=
 
-uuid@^3.3.2, uuid@^3.3.3:
+uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
@@ -6643,17 +6369,20 @@ uuid@^8.3.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
   integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
 
-"v-connection@git+https://github.com/olzzon/v-connection#v20200515_1":
-  version "0.0.11"
-  resolved "git+https://github.com/olzzon/v-connection#8f6cb135096cf36630713b1582ed4928d2754812"
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+"v-connection@git+https://github.com/olzzon/v-connection#vtest20210413_1":
+  version "0.0.1"
+  resolved "git+https://github.com/olzzon/v-connection#56cd7f01bab7d38786ccba900f8c63842d3b9f57"
   dependencies:
-    koa "^2.11.0"
-    request "^2.88.0"
-    request-promise-native "^1.0.7"
-    uuid "^3.3.3"
-    ws "^7.1.2"
-    xml2js "^0.4.22"
-    yargs "^14.2.0"
+    request "^2.88.2"
+    request-promise-native "^1.0.9"
+    uuid "^8.3.2"
+    ws "^7.4.2"
+    xml2js "^0.4.23"
 
 v8-to-istanbul@^5.0.1:
   version "5.0.1"
@@ -6671,11 +6400,6 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
-
-vary@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
-  integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
 verror@1.10.0:
   version "1.10.0"
@@ -6827,15 +6551,6 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
-wrap-ansi@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
-  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
-  dependencies:
-    ansi-styles "^3.2.0"
-    string-width "^3.0.0"
-    strip-ansi "^5.0.0"
-
 wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
@@ -6865,10 +6580,15 @@ ws@7.2.1:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.1.tgz#03ed52423cd744084b2cf42ed197c8b65a936b8e"
   integrity sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A==
 
-ws@^7.1.1, ws@^7.1.2, ws@^7.2.3:
+ws@^7.1.1, ws@^7.2.3:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
   integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
+
+ws@^7.4.2:
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.4.tgz#383bc9742cb202292c9077ceab6f6047b17f2d59"
+  integrity sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==
 
 xdg-basedir@^2.0.0:
   version "2.0.0"
@@ -6900,7 +6620,7 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xml2js@^0.4.19, xml2js@^0.4.22:
+xml2js@^0.4.19, xml2js@^0.4.23:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
   integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
@@ -6943,30 +6663,13 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yargs-parser@20.x, yargs-parser@^15.0.1, yargs-parser@^18.1.2, yargs-parser@^18.1.3:
+yargs-parser@20.x, yargs-parser@^18.1.2, yargs-parser@^18.1.3:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
-
-yargs@^14.2.0:
-  version "14.2.3"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
-  integrity sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==
-  dependencies:
-    cliui "^5.0.0"
-    decamelize "^1.2.0"
-    find-up "^3.0.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^3.0.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^15.0.1"
 
 yargs@^15.3.1:
   version "15.4.1"
@@ -7004,8 +6707,3 @@ yargs@~1.2.6:
   integrity sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=
   dependencies:
     minimist "^0.1.0"
-
-ylru@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ylru/-/ylru-1.2.1.tgz#f576b63341547989c1de7ba288760923b27fe84f"
-  integrity sha512-faQrqNMzcPCHGVC2aaOINk13K+aaBDUPjGWl0teOXywElLjyVAB6Oe2jj62jHYtwsU49jXhScYbvPENK+6zAvQ==


### PR DESCRIPTION
Fixes:
- Loading extra elements when playout gateway is restarted while a rundown is active
- Loading duplicate elements
- Immediate reconnection attempts that might render Playout gateway unresponsive and/or flood the logs (fix in v-connection)
- Unnecessary purging of all loaded elements when going rehearsal<->active
- Delay after activating a rundown to when the first Part can be taken

Adds/improves:
- Monitors Viz Engines and reports if they are disconnected
- Handling baseline expectedPlayoutItems that should not be purged
- Indicating elements as missing when connection to MSE is lost
- Better logging