### PR TITLE
SOF-752 add support for multiple Viz shows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,15 @@
     ]
   },
   "scripts": {
-    "build": "yarn lerna exec yarn build",
+    "build": "yarn build:types && yarn build:main",
+    "build:types": "cd packages/timeline-state-resolver-types && yarn build",
+    "build:main": "cd packages/timeline-state-resolver && yarn build",
     "lint": "yarn lerna exec yarn lint -- --",
+    "link-types": "yarn symlink-dir packages/timeline-state-resolver-types packages/timeline-state-resolver/node_modules/timeline-state-resolver-types",
     "test": "yarn lerna exec yarn test",
     "watch": "lerna run --parallel build:main -- --watch --preserveWatchOutput",
     "docs": "yarn typedoc .",
-    "postinstall": "lerna bootstrap",
+    "postinstall": "lerna bootstrap && yarn link-types",
     "release:set-version": "lerna version --no-changelog --no-git-tag-version --no-push --yes",
     "release:bump-release": "lerna version --exact --conventional-commits --conventional-graduate --tag-version-prefix='' --no-push",
     "release:bump-release-force": "lerna version --exact --conventional-commits --tag-version-prefix='' --no-push --force-publish=*",
@@ -39,6 +42,7 @@
     "lerna": "^4.0.0",
     "open-cli": "^6.0.1",
     "rimraf": "^3.0.2",
+    "symlink-dir": "^5.0.1",
     "ts-jest": "^26.1.0",
     "typedoc": "^0.21.10",
     "typescript": "~4.2"

--- a/packages/timeline-state-resolver-types/package.json
+++ b/packages/timeline-state-resolver-types/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@tv2media/timeline-state-resolver-types",
+	"name": "timeline-state-resolver-types",
 	"version": "1.0.0-release37.4",
 	"description": "Have timeline, control stuff",
 	"main": "dist/index.js",

--- a/packages/timeline-state-resolver-types/src/vizMSE.ts
+++ b/packages/timeline-state-resolver-types/src/vizMSE.ts
@@ -14,8 +14,6 @@ export interface VizMSEOptions {
 	/** Port number to the REST interfaces of Viz Engines (optional) */
 	engineRestPort?: number
 
-	/** Identifier of the "show" to use */
-	showID: string
 	/** Identifier of the "profile" to send commands to */
 	profile: string
 	/** Identifier of the "playlist" to send commands to */
@@ -51,7 +49,7 @@ export enum TimelineContentTypeVizMSE {
 	CONTINUE = 'continue',
 	LOAD_ALL_ELEMENTS = 'load_all_elements',
 	CLEAR_ALL_ELEMENTS = 'clear_all_elements',
-	ALL_SHOWS = 'all_shows',
+	CLEANUP_SHOWS = 'cleanup_shows',
 	INITIALIZE_SHOWS = 'initialize_shows',
 }
 
@@ -62,7 +60,7 @@ export type TimelineObjVIZMSEAny =
 	| TimelineObjVIZMSELoadAllElements
 	| TimelineObjVIZMSEClearAllElements
 	| TimelineObjVIZMSEInitializeShows
-	| TimelineObjVIZMSEAllShows
+	| TimelineObjVIZMSECleanupShows
 
 export interface TimelineObjVIZMSEBase extends TSRTimelineObjBase {
 	content: {
@@ -177,16 +175,16 @@ export interface TimelineObjVIZMSEInitializeShows extends TSRTimelineObjBase {
 		type: TimelineContentTypeVizMSE.INITIALIZE_SHOWS
 
 		/** IDs of the Shows to initialize */
-		showIds?: string[]
+		showIds: string[]
 	}
 }
-export interface TimelineObjVIZMSEAllShows extends TSRTimelineObjBase {
+export interface TimelineObjVIZMSECleanupShows extends TSRTimelineObjBase {
 	content: {
 		deviceType: DeviceType.VIZMSE
-		type: TimelineContentTypeVizMSE.ALL_SHOWS
+		type: TimelineContentTypeVizMSE.CLEANUP_SHOWS
 
-		/** IDs of all the Shows that Sofie manages, that might need to be cleaned up at some point */
-		showIds?: string[]
+		/** IDs of the Shows to cleanup */
+		showIds: string[]
 	}
 }
 

--- a/packages/timeline-state-resolver-types/src/vizMSE.ts
+++ b/packages/timeline-state-resolver-types/src/vizMSE.ts
@@ -51,6 +51,8 @@ export enum TimelineContentTypeVizMSE {
 	CONTINUE = 'continue',
 	LOAD_ALL_ELEMENTS = 'load_all_elements',
 	CLEAR_ALL_ELEMENTS = 'clear_all_elements',
+	ALL_SHOWS = 'all_shows',
+	INITIALIZE_SHOWS = 'initialize_shows',
 }
 
 export type TimelineObjVIZMSEAny =
@@ -59,6 +61,8 @@ export type TimelineObjVIZMSEAny =
 	| TimelineObjVIZMSEElementContinue
 	| TimelineObjVIZMSELoadAllElements
 	| TimelineObjVIZMSEClearAllElements
+	| TimelineObjVIZMSEInitializeShows
+	| TimelineObjVIZMSEAllShows
 
 export interface TimelineObjVIZMSEBase extends TSRTimelineObjBase {
 	content: {
@@ -105,6 +109,8 @@ export interface TimelineObjVIZMSEElementInternal extends TimelineObjVIZMSEBase 
 		templateName: string
 		/** Data to be fed into the template */
 		templateData: Array<string>
+		/** Which Show to place this element in */
+		showId: string
 		/** Whether this element should have its take delayed until after an out transition has finished */
 		delayTakeAfterOutTransition?: boolean
 	}
@@ -160,6 +166,27 @@ export interface TimelineObjVIZMSEClearAllElements extends TSRTimelineObjBase {
 
 		/** Names of the channels to send the special clear commands to */
 		channelsToSendCommands?: string[]
+
+		/** IDs of the Show to use for taking the special template */
+		showId: string
+	}
+}
+export interface TimelineObjVIZMSEInitializeShows extends TSRTimelineObjBase {
+	content: {
+		deviceType: DeviceType.VIZMSE
+		type: TimelineContentTypeVizMSE.INITIALIZE_SHOWS
+
+		/** IDs of the Shows to initialize */
+		showIds?: string[]
+	}
+}
+export interface TimelineObjVIZMSEAllShows extends TSRTimelineObjBase {
+	content: {
+		deviceType: DeviceType.VIZMSE
+		type: TimelineContentTypeVizMSE.ALL_SHOWS
+
+		/** IDs of all the Shows that Sofie manages, that might need to be cleaned up at some point */
+		showIds?: string[]
 	}
 }
 
@@ -176,14 +203,26 @@ export interface VIZMSETransitionDelay {
 	// For how long to delay the take out (ms)
 	delay: number
 }
-export interface VIZMSEPlayoutItemContent {
-	/** Name of the element, or Pilot Element */
-	templateName: string | number // if number, it's a vizPilot element
-	/** Data fields of the element (for internal elements only) */
-	templateData?: string[]
+export interface VIZMSEPlayoutItemContentBase {
 	/** What channel to use for the element */
-	channelName?: string
+	channel?: string
 
 	/** If true, won't be preloaded (cued) automatically */
 	noAutoPreloading?: boolean
 }
+
+export interface VIZMSEPlayoutItemContentInternal extends VIZMSEPlayoutItemContentBase {
+	/** Name of the template that this element uses */
+	templateName: string
+	/** Data fields of the element */
+	templateData?: string[]
+	/** Which Show to place this element in */
+	showId: string
+}
+
+export interface VIZMSEPlayoutItemContentExternal extends VIZMSEPlayoutItemContentBase {
+	/** Id of the Pilot Element */
+	vcpid: number
+}
+
+export type VIZMSEPlayoutItemContent = VIZMSEPlayoutItemContentExternal | VIZMSEPlayoutItemContentInternal

--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -84,7 +84,7 @@
     "production"
   ],
   "dependencies": {
-    "@tv2media/v-connection": "^5.1.2",
+    "@tv2media/v-connection": "^6.0.0",
     "atem-connection": "^2.3.0",
     "atem-state": "0.12.2-nightly-latest-20211007-163338-78e7dca.0",
     "casparcg-connection": "^5.1.0",

--- a/packages/timeline-state-resolver/src/__mocks__/v-connection.ts
+++ b/packages/timeline-state-resolver/src/__mocks__/v-connection.ts
@@ -11,6 +11,10 @@ import {
 	ExternalElement,
 	VElement,
 	ExternalElementId,
+	InternalElementId,
+	ElementId,
+	isInternalElement,
+	isExternalElement,
 } from '@tv2media/v-connection'
 import { EventEmitter } from 'events'
 import { CommandResult } from '@tv2media/v-connection/dist/msehttp'
@@ -76,9 +80,9 @@ export class MSEMock extends EventEmitter implements MSE {
 	async listShows(): Promise<string[]> {
 		return []
 	}
-	async getShow(showName: string): Promise<VShow> {
+	async getShow(showID: string): Promise<VShow> {
 		return {
-			id: 'mockshowid_' + showName,
+			id: 'mockshowid_' + showID,
 		}
 	}
 	async listPlaylists(): Promise<string[]> {
@@ -94,14 +98,9 @@ export class MSEMock extends EventEmitter implements MSE {
 			},
 		}
 	}
-	async createRundown(
-		showID: string,
-		profile: string,
-		playlistId?: string,
-		description?: string
-	): Promise<VRundownMock> {
+	async createRundown(profile: string, playlistId?: string, description?: string): Promise<VRundownMock> {
 		if (!playlistId) playlistId = 'mockrandomPlaylist' + Date.now()
-		const rundown = new VRundownMock(showID, profile, playlistId, description)
+		const rundown = new VRundownMock(profile, playlistId, description)
 
 		this.rundowns[playlistId] = rundown
 
@@ -166,12 +165,7 @@ export type VRundownMocked = MockClass<VRundown>
 export class VRundownMock implements VRundown {
 	private elements: { [key: string]: VElement } = {}
 	private _isActive = false
-	constructor(
-		public readonly show: string,
-		public readonly profile: string,
-		public readonly playlist: string,
-		public readonly description?: string
-	) {
+	constructor(public readonly profile: string, public readonly playlist: string, public readonly description?: string) {
 		// Hack: replace methods with jest-ified ones
 		_.each(Object.getOwnPropertyNames(VRundownMock.prototype), (key) => {
 			if (key !== 'prototype') {
@@ -180,6 +174,24 @@ export class VRundownMock implements VRundown {
 				}
 			}
 		})
+	}
+
+	private static getElementHash(elementId: ElementId): string {
+		if (isInternalElement(elementId)) {
+			return `${elementId.instanceName}_${elementId.showId}`
+		} else {
+			return `${elementId.vcpid}_${elementId.channel}`
+		}
+	}
+
+	listInternalElements(_showId: string): Promise<InternalElementId[]> {
+		throw new Error('Method not implemented.')
+	}
+	async initializeShow(_showId: string): Promise<CommandResult> {
+		return { path: '', status: 200, response: 'mock' }
+	}
+	async cleanupShow(_showId: string): Promise<CommandResult> {
+		return { path: '', status: 200, response: 'mock' }
 	}
 
 	async listTemplates(): Promise<string[]> {
@@ -191,27 +203,26 @@ export class VRundownMock implements VRundown {
 			defaultAlternatives: {}, // any
 		}
 	}
-	async createElement(vcpid: number, channel?: string, alias?: string): Promise<ExternalElement>
+	async createElement(elementId: ExternalElementId): Promise<ExternalElement>
 	async createElement(
+		elementId: InternalElementId,
 		templateName: string,
-		elementName: string,
 		textFields: string[],
 		channel?: string
 	): Promise<InternalElement>
 	async createElement(
-		templateNameOrVcpid: any,
-		elementNameOrChannel?: any,
-		textFieldsOrAlias?: any,
+		elementId: ElementId,
+		templateName?: string,
+		textFields?: string[],
 		channel?: string
 	): Promise<ExternalElement | InternalElement> {
-		if (typeof templateNameOrVcpid === 'number') {
-			const vcpid = templateNameOrVcpid
-			const channel = elementNameOrChannel
+		const hash = VRundownMock.getElementHash(elementId)
+		if (isExternalElement(elementId)) {
 			// const alias = textFieldsOrAlias
 
 			const el: ExternalElement = {
-				channel: channel,
-				vcpid: '' + vcpid,
+				channel: elementId.channel,
+				vcpid: elementId.vcpid.toString(),
 				// available?: string,
 				// is_loading?: string,
 				// loaded?: string,
@@ -221,35 +232,31 @@ export class VRundownMock implements VRundown {
 				// name?: string
 			}
 
-			this.elements['' + vcpid] = el
+			this.elements[hash] = el
 			return el
 		} else {
-			const templateName = templateNameOrVcpid
-			const elementName = elementNameOrChannel
-			const textFields = textFieldsOrAlias
-
 			const data: any = {}
-			_.each(textFields, (val, key) => {
+			_.each(textFields!, (val, key) => {
 				data['v' + key] = val
 			})
 			const el: InternalElement = {
 				channel: channel,
-				name: elementName,
-				template: templateName,
+				name: elementId.instanceName,
+				template: templateName!,
 				data: data,
 			}
-			this.elements[elementName] = el
+			this.elements[hash] = el
 			return el
 		}
 	}
-	async listElements(): Promise<Array<string | ExternalElementId>> {
+	async listExternalElements(): Promise<Array<ExternalElementId>> {
 		return []
 	}
-	async getElement(elementName: string | number): Promise<VElement> {
-		return this.elements[elementName]
+	async getElement(elementId: ElementId): Promise<VElement> {
+		return this.elements[VRundownMock.getElementHash(elementId)]
 	}
-	async deleteElement(elementName: string | number): Promise<PepResponse> {
-		delete this.elements[elementName]
+	async deleteElement(elementId: ElementId): Promise<PepResponse> {
+		delete this.elements[VRundownMock.getElementHash(elementId)]
 
 		return {
 			id: '*',
@@ -258,23 +265,23 @@ export class VRundownMock implements VRundown {
 			body: 'mock',
 		}
 	}
-	async cue(_elementName: string | number): Promise<CommandResult> {
+	async cue(_elementId: ElementId): Promise<CommandResult> {
 		return { path: '', status: 200, response: 'mock' }
 	}
-	async take(_elementName: string | number): Promise<CommandResult> {
+	async take(_elementId: ElementId): Promise<CommandResult> {
 		return { path: '', status: 200, response: 'mock' }
 	}
-	async continue(_elementName: string | number): Promise<CommandResult> {
+	async continue(_elementId: ElementId): Promise<CommandResult> {
 		return { path: '', status: 200, response: 'mock' }
 	}
-	async continueReverse(_elementName: string | number): Promise<CommandResult> {
+	async continueReverse(_elementId: ElementId): Promise<CommandResult> {
 		return { path: '', status: 200, response: 'mock' }
 	}
-	async out(_elementName: string | number): Promise<CommandResult> {
+	async out(_elementId: ElementId): Promise<CommandResult> {
 		return { path: '', status: 200, response: 'mock' }
 	}
-	async initialize(_elementName: number): Promise<CommandResult> {
-		const el = this.elements[_elementName]
+	async initialize(elementId: ExternalElementId): Promise<CommandResult> {
+		const el = this.elements[VRundownMock.getElementHash(elementId)]
 		if (!el) throw new Error('Element not found')
 
 		// available?: string,
@@ -299,7 +306,7 @@ export class VRundownMock implements VRundown {
 	async cleanup(): Promise<CommandResult> {
 		return { path: '', status: 200, response: 'mock' }
 	}
-	async purge(_elementsToKeep?: ExternalElementId[]): Promise<PepResponse> {
+	async purge(_showIds: string[], _elementsToKeep?: ExternalElementId[]): Promise<PepResponse> {
 		return { id: '*', status: 'ok', body: 'mock' }
 	}
 	async isActive(): Promise<boolean> {

--- a/packages/timeline-state-resolver/src/__mocks__/v-connection.ts
+++ b/packages/timeline-state-resolver/src/__mocks__/v-connection.ts
@@ -178,11 +178,9 @@ export class VRundownMock implements VRundown {
 	}
 
 	private static getElementHash(elementId: ElementId): string {
-		if (isInternalElement(elementId)) {
-			return `${elementId.instanceName}_${elementId.showId}`
-		} else {
-			return `${elementId.vcpid}_${elementId.channel}`
-		}
+		return isInternalElement(elementId)
+			? `${elementId.instanceName}_${elementId.showId}`
+			: `${elementId.vcpid}_${elementId.channel}`
 	}
 
 	listInternalElements(_showId: string): Promise<InternalElementId[]> {

--- a/packages/timeline-state-resolver/src/__mocks__/v-connection.ts
+++ b/packages/timeline-state-resolver/src/__mocks__/v-connection.ts
@@ -306,7 +306,14 @@ export class VRundownMock implements VRundown {
 	async cleanup(): Promise<CommandResult> {
 		return { path: '', status: 200, response: 'mock' }
 	}
-	async purge(_showIds: string[], _elementsToKeep?: ExternalElementId[]): Promise<PepResponse> {
+	async purgeInternalElements(
+		_showIds: string[],
+		_onlyCreatedByUs?: boolean,
+		_elementsToKeep?: InternalElementId[]
+	): Promise<PepResponse> {
+		return { id: '*', status: 'ok', body: 'mock' }
+	}
+	async purgeExternalElements(_elementsToKeep?: ExternalElementId[]): Promise<PepResponse> {
 		return { id: '*', status: 'ok', body: 'mock' }
 	}
 	async isActive(): Promise<boolean> {

--- a/packages/timeline-state-resolver/src/devices/__tests__/vizMSE.spec.ts
+++ b/packages/timeline-state-resolver/src/devices/__tests__/vizMSE.spec.ts
@@ -7,6 +7,7 @@ import {
 	TimelineContentTypeVizMSE,
 	VIZMSETransitionType,
 	VizMSEOptions,
+	VIZMSEPlayoutItemContentExternal,
 } from 'timeline-state-resolver-types'
 import { MockTime } from '../../__tests__/mockTime'
 import { ThreadedClass } from 'threadedclass'
@@ -18,6 +19,8 @@ type MSEMock = vConnection.MSEMock
 type VRundownMocked = vConnection.VRundownMocked
 import _ = require('underscore')
 import { literal, StatusCode } from '../device'
+
+const SHOW_ID = '34ea2db4-ad93-42fb-b352-e49f926ed83f'
 
 describe('vizMSE', () => {
 	const mockTime = new MockTime()
@@ -94,6 +97,7 @@ describe('vizMSE', () => {
 					// noAutoPreloading?: boolean
 					templateName: 'myInternalElement',
 					templateData: ['line1', 'line2'],
+					showId: SHOW_ID,
 				},
 			},
 			{
@@ -108,6 +112,7 @@ describe('vizMSE', () => {
 					type: TimelineContentTypeVizMSE.ELEMENT_INTERNAL,
 					templateName: 'myInternalElement2',
 					templateData: ['line1'],
+					showId: SHOW_ID,
 				},
 			},
 			{
@@ -136,10 +141,13 @@ describe('vizMSE', () => {
 			// fromLookahead?: boolean
 			// layerId?: string
 			time: 14100,
-			templateInstance: expect.stringContaining('myInternalElement'),
+			content: {
+				instanceName: expect.stringContaining('myInternalElement'),
+				templateName: 'myInternalElement',
+				templateData: ['line1', 'line2'],
+				showId: SHOW_ID,
+			},
 			type: 'prepare',
-			templateName: 'myInternalElement',
-			templateData: ['line1', 'line2'],
 			// channelName?: string
 			// noAutoPreloading?: boolean
 		})
@@ -150,10 +158,13 @@ describe('vizMSE', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			timelineObjId: 'obj0',
 			time: 15100,
-			templateInstance: expect.stringContaining('myInternalElement'),
+			content: {
+				instanceName: expect.stringContaining('myInternalElement'),
+				templateName: 'myInternalElement',
+				templateData: ['line1', 'line2'],
+				showId: SHOW_ID,
+			},
 			type: 'take',
-			templateName: 'myInternalElement',
-			templateData: ['line1', 'line2'],
 		})
 
 		commandReceiver0.mockClear()
@@ -162,10 +173,13 @@ describe('vizMSE', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			timelineObjId: 'obj1',
 			time: 16100,
-			templateInstance: expect.stringContaining('myInternalElement2'),
+			content: {
+				instanceName: expect.stringContaining('myInternalElement2'),
+				templateName: 'myInternalElement2',
+				templateData: ['line1'],
+				showId: SHOW_ID,
+			},
 			type: 'prepare',
-			templateName: 'myInternalElement2',
-			templateData: ['line1'],
 		})
 
 		commandReceiver0.mockClear()
@@ -174,10 +188,13 @@ describe('vizMSE', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			timelineObjId: 'obj1',
 			time: 17100,
-			templateInstance: expect.stringContaining('myInternalElement2'),
+			content: {
+				instanceName: expect.stringContaining('myInternalElement2'),
+				templateName: 'myInternalElement2',
+				templateData: ['line1'],
+				showId: SHOW_ID,
+			},
 			type: 'take',
-			templateName: 'myInternalElement2',
-			templateData: ['line1'],
 		})
 
 		commandReceiver0.mockClear()
@@ -186,10 +203,13 @@ describe('vizMSE', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			timelineObjId: 'obj2',
 			time: 19100,
-			templateInstance: expect.stringContaining('myInternalElement2'),
+			content: {
+				instanceName: expect.stringContaining('myInternalElement2'),
+				templateName: 'myInternalElement2',
+				templateData: ['line1'],
+				showId: SHOW_ID,
+			},
 			type: 'continue',
-			templateName: 'myInternalElement2',
-			templateData: ['line1'],
 		})
 
 		commandReceiver0.mockClear()
@@ -198,10 +218,13 @@ describe('vizMSE', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			timelineObjId: 'obj1',
 			time: 22100,
-			templateInstance: expect.stringContaining('myInternalElement2'),
+			content: {
+				instanceName: expect.stringContaining('myInternalElement2'),
+				templateName: 'myInternalElement2',
+				templateData: ['line1'],
+				showId: SHOW_ID,
+			},
 			type: 'out',
-			templateName: 'myInternalElement2',
-			templateData: ['line1'],
 		})
 	})
 	test('vizMSE: External/Pilot element', async () => {
@@ -310,25 +333,20 @@ describe('vizMSE', () => {
 		expect(rundown).toBeTruthy()
 
 		expect(await device.supportsExpectedPlayoutItems).toEqual(true)
-		await device.handleExpectedPlayoutItems([
-			{
-				templateName: 1337,
-				// templateData?: string[]
-				channelName: 'FULL1',
-				// noAutoPreloading?: boolean
-			},
-			{
-				templateName: 1336,
-				// templateData?: string[]
-				channelName: 'FULL1',
-				// noAutoPreloading?: boolean
-			},
-		])
+		const expectedItem1: VIZMSEPlayoutItemContentExternal = {
+			vcpid: 1337,
+			channel: 'FULL1',
+		}
+		const expectedItem2: VIZMSEPlayoutItemContentExternal = {
+			vcpid: 1336,
+			channel: 'FULL1',
+		}
+		await device.handleExpectedPlayoutItems([expectedItem1, expectedItem2])
 		await mockTime.advanceTimeTicks(100)
 
 		expect(rundown.createElement).toHaveBeenCalledTimes(2)
-		expect(rundown.createElement).toHaveBeenNthCalledWith(1, 1337, 'FULL1')
-		expect(rundown.createElement).toHaveBeenNthCalledWith(2, 1336, 'FULL1')
+		expect(rundown.createElement).toHaveBeenNthCalledWith(1, expectedItem1)
+		expect(rundown.createElement).toHaveBeenNthCalledWith(2, expectedItem2)
 		rundown.createElement.mockClear()
 
 		await myConductor.devicesMakeReady(true)
@@ -337,16 +355,16 @@ describe('vizMSE', () => {
 		expect(rundown.activate).toHaveBeenCalledTimes(2)
 
 		expect(rundown.getElement).toHaveBeenCalledTimes(4)
-		expect(rundown.getElement).nthCalledWith(1, 1337, 'FULL1')
-		expect(rundown.getElement).nthCalledWith(2, 1336, 'FULL1')
+		expect(rundown.getElement).nthCalledWith(1, expectedItem1)
+		expect(rundown.getElement).nthCalledWith(2, expectedItem2)
 
 		expect(rundown.createElement).toHaveBeenCalledTimes(2)
-		expect(rundown.createElement).toHaveBeenNthCalledWith(1, 1337, 'FULL1')
-		expect(rundown.createElement).toHaveBeenNthCalledWith(2, 1336, 'FULL1')
+		expect(rundown.createElement).toHaveBeenNthCalledWith(1, expectedItem1)
+		expect(rundown.createElement).toHaveBeenNthCalledWith(2, expectedItem2)
 
 		expect(rundown.initialize).toHaveBeenCalledTimes(2)
-		expect(rundown.initialize).nthCalledWith(1, 1337, 'FULL1')
-		expect(rundown.initialize).nthCalledWith(2, 1336, 'FULL1')
+		expect(rundown.initialize).nthCalledWith(1, expectedItem1)
+		expect(rundown.initialize).nthCalledWith(2, expectedItem2)
 
 		commandReceiver0.mockClear()
 		await mockTime.advanceTimeToTicks(14500)
@@ -356,10 +374,11 @@ describe('vizMSE', () => {
 			// fromLookahead?: boolean
 			// layerId?: string
 			time: 14100,
-			templateInstance: expect.stringContaining('pilot_1337'),
+			content: {
+				vcpid: 1337,
+				channel: 'FULL1',
+			},
 			type: 'prepare',
-			templateName: 1337,
-			channelName: 'FULL1',
 			// noAutoPreloading?: boolean
 		})
 
@@ -369,10 +388,11 @@ describe('vizMSE', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			timelineObjId: 'obj0',
 			time: 15100,
-			templateInstance: expect.stringContaining('pilot_1337'),
+			content: {
+				vcpid: 1337,
+				channel: 'FULL1',
+			},
 			type: 'take',
-			templateName: 1337,
-			channelName: 'FULL1',
 		})
 
 		commandReceiver0.mockClear()
@@ -381,10 +401,11 @@ describe('vizMSE', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			timelineObjId: 'obj1',
 			time: 16100,
-			templateInstance: expect.stringContaining('pilot_1338'),
+			content: {
+				vcpid: 1338,
+				channel: 'FULL1',
+			},
 			type: 'prepare',
-			templateName: 1338,
-			channelName: 'FULL1',
 		})
 
 		commandReceiver0.mockClear()
@@ -393,10 +414,11 @@ describe('vizMSE', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			timelineObjId: 'obj1',
 			time: 17100,
-			templateInstance: expect.stringContaining('pilot_1338'),
+			content: {
+				vcpid: 1338,
+				channel: 'FULL1',
+			},
 			type: 'take',
-			templateName: 1338,
-			channelName: 'FULL1',
 		})
 
 		commandReceiver0.mockClear()
@@ -405,10 +427,11 @@ describe('vizMSE', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			timelineObjId: 'obj2',
 			time: 19100,
-			templateInstance: expect.stringContaining('pilot_1338'),
+			content: {
+				vcpid: 1338,
+				channel: 'FULL1',
+			},
 			type: 'continue',
-			templateName: 1338,
-			channelName: 'FULL1',
 		})
 
 		commandReceiver0.mockClear()
@@ -417,10 +440,11 @@ describe('vizMSE', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			timelineObjId: 'obj1',
 			time: 22100,
-			templateInstance: expect.stringContaining('pilot_1338'),
+			content: {
+				vcpid: 1338,
+				channel: 'FULL1',
+			},
 			type: 'out',
-			templateName: 1338,
-			channelName: 'FULL1',
 		})
 
 		// manually load elements:
@@ -429,20 +453,12 @@ describe('vizMSE', () => {
 		rundown.createElement.mockClear()
 		rundown.initialize.mockClear()
 
-		await device.handleExpectedPlayoutItems([
-			{
-				templateName: 1337,
-				channelName: 'FULL1',
-			},
-			{
-				templateName: 1336,
-				channelName: 'FULL1',
-			},
-			{
-				templateName: 9999,
-				channelName: 'FULL1',
-			},
-		])
+		const expectedItem3: VIZMSEPlayoutItemContentExternal = {
+			vcpid: 9999,
+			channel: 'FULL1',
+		}
+
+		await device.handleExpectedPlayoutItems([expectedItem1, expectedItem2, expectedItem3])
 
 		myConductor.setTimelineAndMappings([
 			{
@@ -462,7 +478,7 @@ describe('vizMSE', () => {
 		await mockTime.advanceTimeToTicks(24900)
 
 		expect(rundown.createElement).toHaveBeenCalledTimes(1)
-		expect(rundown.createElement).toHaveBeenNthCalledWith(1, 9999, 'FULL1')
+		expect(rundown.createElement).toHaveBeenNthCalledWith(1, expectedItem3)
 		expect(rundown.initialize).toHaveBeenCalledTimes(0)
 
 		rundown.getElement.mockClear()
@@ -478,7 +494,7 @@ describe('vizMSE', () => {
 		})
 
 		expect(rundown.initialize).toHaveBeenCalledTimes(1)
-		expect(rundown.initialize).nthCalledWith(1, 9999, 'FULL1')
+		expect(rundown.initialize).nthCalledWith(1, expectedItem3)
 
 		expect(rundown.deactivate).toHaveBeenCalledTimes(0)
 		await myConductor.devicesStandDown(true)
@@ -638,6 +654,7 @@ describe('vizMSE', () => {
 					type: TimelineContentTypeVizMSE.ELEMENT_INTERNAL,
 					templateName: 'myInternalElement',
 					templateData: [],
+					showId: SHOW_ID,
 				},
 			},
 			{
@@ -651,7 +668,7 @@ describe('vizMSE', () => {
 					deviceType: DeviceType.VIZMSE,
 					type: TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS,
 					channelsToSendCommands: ['OVL', 'FULL'],
-					commands: ['RENDERER*FRONT_LAYER SET_OBJECT ', 'RENDERER SET_OBJECT '],
+					showId: SHOW_ID,
 				},
 			},
 		] as TSRTimeline)
@@ -679,18 +696,24 @@ describe('vizMSE', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			timelineObjId: 'obj0',
 			time: 10105,
-			templateInstance: expect.stringContaining('myInternalElement'),
+			content: {
+				instanceName: expect.stringContaining('myInternalElement'),
+				templateName: 'myInternalElement',
+				templateData: [],
+				showId: SHOW_ID,
+			},
 			type: 'prepare',
-			templateName: 'myInternalElement',
-			templateData: [],
 		})
 		expect(getMockCall(commandReceiver0, 1, 1)).toMatchObject({
 			timelineObjId: 'obj0',
 			time: 10105,
-			templateInstance: expect.stringContaining('myInternalElement'),
+			content: {
+				instanceName: expect.stringContaining('myInternalElement'),
+				templateName: 'myInternalElement',
+				templateData: [],
+				showId: SHOW_ID,
+			},
 			type: 'take',
-			templateName: 'myInternalElement',
-			templateData: [],
 		})
 
 		commandReceiver0.mockClear()
@@ -712,10 +735,13 @@ describe('vizMSE', () => {
 		expect(getMockCall(commandReceiver0, 2, 1)).toMatchObject({
 			timelineObjId: 'obj0',
 			time: 15150,
-			templateInstance: expect.stringContaining('myInternalElement'),
+			content: {
+				instanceName: expect.stringContaining('myInternalElement'),
+				templateName: 'myInternalElement',
+				templateData: [],
+				showId: SHOW_ID,
+			},
 			type: 'prepare',
-			templateName: 'myInternalElement',
-			templateData: [],
 		})
 
 		commandReceiver0.mockClear()
@@ -724,10 +750,13 @@ describe('vizMSE', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			timelineObjId: 'obj0',
 			time: 16100,
-			templateInstance: expect.stringContaining('myInternalElement'),
+			content: {
+				instanceName: expect.stringContaining('myInternalElement'),
+				templateName: 'myInternalElement',
+				templateData: [],
+				showId: SHOW_ID,
+			},
 			type: 'take',
-			templateName: 'myInternalElement',
-			templateData: [],
 		})
 
 		commandReceiver0.mockClear()
@@ -736,10 +765,13 @@ describe('vizMSE', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			timelineObjId: 'obj0',
 			time: 20100,
-			templateInstance: expect.stringContaining('myInternalElement'),
+			content: {
+				instanceName: expect.stringContaining('myInternalElement'),
+				templateName: 'myInternalElement',
+				templateData: [],
+				showId: SHOW_ID,
+			},
 			type: 'out',
-			templateName: 'myInternalElement',
-			templateData: [],
 		})
 	})
 	test('vizMSE: Delayed External/Pilot element', async () => {
@@ -826,9 +858,11 @@ describe('vizMSE', () => {
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
 			timelineObjId: 'obj0',
 			time: 14100,
+			content: {
+				vcpid: 1337,
+				channel: 'FULL1',
+			},
 			type: 'prepare',
-			templateName: 1337,
-			channelName: 'FULL1',
 		})
 
 		commandReceiver0.mockClear()
@@ -836,7 +870,10 @@ describe('vizMSE', () => {
 		await mockTime.advanceTimeToTicks(15500)
 		expect(commandReceiver0.mock.calls.length).toEqual(1)
 		expect(rundown.take).toHaveBeenCalledTimes(1)
-		expect(rundown.take).nthCalledWith(1, 1337, 'FULL1')
+		expect(rundown.take).nthCalledWith(1, {
+			vcpid: 1337,
+			channel: 'FULL1',
+		})
 		expect(rundown.out).toHaveBeenCalledTimes(0)
 
 		commandReceiver0.mockClear()
@@ -848,7 +885,10 @@ describe('vizMSE', () => {
 		commandReceiver0.mockClear()
 		await mockTime.advanceTimeToTicks(21200)
 		expect(rundown.out).toHaveBeenCalledTimes(1)
-		expect(rundown.out).nthCalledWith(1, 1337, 'FULL1')
+		expect(rundown.out).nthCalledWith(1, {
+			vcpid: 1337,
+			channel: 'FULL1',
+		})
 		expect(rundown.take).toHaveBeenCalledTimes(0)
 
 		expect(onError).toHaveBeenCalledTimes(0)

--- a/packages/timeline-state-resolver/src/devices/__tests__/vizMSE.spec.ts
+++ b/packages/timeline-state-resolver/src/devices/__tests__/vizMSE.spec.ts
@@ -23,9 +23,53 @@ import { literal, StatusCode } from '../device'
 
 const SHOW_ID = '34ea2db4-ad93-42fb-b352-e49f926ed83f'
 
-describe('vizMSE', () => {
-	const mockTime = new MockTime()
+async function setupDevice() {
+	let device: any = undefined
+	const commandReceiver0 = jest.fn((...args) => {
+		return device._defaultCommandReceiver(...args)
+	})
 
+	const myChannelMapping0: MappingVizMSE = {
+		device: DeviceType.VIZMSE,
+		deviceId: 'myViz',
+	}
+	const myChannelMapping1: MappingVizMSE = {
+		device: DeviceType.VIZMSE,
+		deviceId: 'myViz',
+	}
+	const myChannelMapping: Mappings = {
+		viz0: myChannelMapping0,
+		viz_continue: myChannelMapping1,
+	}
+
+	const myConductor = new Conductor({
+		initializeAsClear: true,
+		getCurrentTime: mockTime.getCurrentTime,
+	})
+	const onError = jest.fn()
+	myConductor.on('error', onError)
+
+	myConductor.setTimelineAndMappings([], myChannelMapping)
+	await myConductor.init()
+	await myConductor.addDevice('myViz', {
+		type: DeviceType.VIZMSE,
+		options: {
+			host: '127.0.0.1',
+			preloadAllElements: true,
+			playlistID: 'my-super-playlist-id',
+			profile: 'profile9999',
+		},
+		commandReceiver: commandReceiver0,
+	})
+	const deviceContainer = myConductor.getDevice('myViz')
+	device = deviceContainer!.device as ThreadedClass<VizMSEDevice>
+
+	return { device, myConductor, onError, commandReceiver0 }
+}
+
+const mockTime = new MockTime()
+
+describe('vizMSE', () => {
 	jest.mock('@tv2media/v-connection', () => vConnection)
 
 	// const orgSetTimeout = setTimeout
@@ -37,44 +81,9 @@ describe('vizMSE', () => {
 		mockTime.init()
 	})
 	test('vizMSE: Internal element', async () => {
-		const commandReceiver0 = jest.fn(() => {
-			return Promise.resolve()
-		})
-		const myChannelMapping0: MappingVizMSE = {
-			device: DeviceType.VIZMSE,
-			deviceId: 'myViz',
-		}
-		const myChannelMapping1: MappingVizMSE = {
-			device: DeviceType.VIZMSE,
-			deviceId: 'myViz',
-		}
-		const myChannelMapping: Mappings = {
-			viz0: myChannelMapping0,
-			viz_continue: myChannelMapping1,
-		}
-
-		const myConductor = new Conductor({
-			multiThreadedResolver: false,
-			initializeAsClear: true,
-			getCurrentTime: mockTime.getCurrentTime,
-		})
-		myConductor.setTimelineAndMappings([], myChannelMapping)
-		await myConductor.init()
-		await myConductor.addDevice('myViz', {
-			isMultiThreaded: false,
-			type: DeviceType.VIZMSE,
-			options: {
-				host: '127.0.0.1',
-				preloadAllElements: true,
-				playlistID: 'my-super-playlist-id',
-				profile: 'profile9999',
-			},
-			commandReceiver: commandReceiver0,
-		})
+		const { device, myConductor, commandReceiver0 } = await setupDevice()
 		await mockTime.advanceTimeToTicks(10100)
 
-		const deviceContainer = myConductor.getDevice('myViz')
-		const device = deviceContainer!.device as ThreadedClass<VizMSEDevice>
 		await device.ignoreWaitsInTests()
 
 		// Check that no commands has been scheduled:
@@ -228,48 +237,8 @@ describe('vizMSE', () => {
 		})
 	})
 	test('vizMSE: External/Pilot element', async () => {
-		let device: any = undefined
-
-		const commandReceiver0 = jest.fn((...args) => {
-			return device._defaultCommandReceiver(...args)
-		})
-
-		const myChannelMapping0: MappingVizMSE = {
-			device: DeviceType.VIZMSE,
-			deviceId: 'myViz',
-		}
-		const myChannelMapping1: MappingVizMSE = {
-			device: DeviceType.VIZMSE,
-			deviceId: 'myViz',
-		}
-		const myChannelMapping: Mappings = {
-			viz0: myChannelMapping0,
-			viz_continue: myChannelMapping1,
-		}
-
-		const myConductor = new Conductor({
-			initializeAsClear: true,
-			getCurrentTime: mockTime.getCurrentTime,
-		})
-		const onError = jest.fn()
-		myConductor.on('error', onError)
-
-		myConductor.setTimelineAndMappings([], myChannelMapping)
-		await myConductor.init()
-		await myConductor.addDevice('myViz', {
-			type: DeviceType.VIZMSE,
-			options: {
-				host: '127.0.0.1',
-				preloadAllElements: true,
-				playlistID: 'my-super-playlist-id',
-				profile: 'profile9999',
-			},
-			commandReceiver: commandReceiver0,
-		})
+		const { device, myConductor, onError, commandReceiver0 } = await setupDevice()
 		await mockTime.advanceTimeToTicks(10100)
-
-		const deviceContainer = myConductor.getDevice('myViz')
-		device = deviceContainer!.device as ThreadedClass<VizMSEDevice>
 
 		await device.ignoreWaitsInTests()
 		// Check that no commands has been scheduled:
@@ -759,47 +728,9 @@ describe('vizMSE', () => {
 		})
 	})
 	test('vizMSE: Delayed External/Pilot element', async () => {
-		let device: any = undefined
-		const commandReceiver0 = jest.fn((...args) => {
-			return device._defaultCommandReceiver(...args)
-		})
-
-		const myChannelMapping0: MappingVizMSE = {
-			device: DeviceType.VIZMSE,
-			deviceId: 'myViz',
-		}
-		const myChannelMapping1: MappingVizMSE = {
-			device: DeviceType.VIZMSE,
-			deviceId: 'myViz',
-		}
-		const myChannelMapping: Mappings = {
-			viz0: myChannelMapping0,
-			viz_continue: myChannelMapping1,
-		}
-
-		const myConductor = new Conductor({
-			initializeAsClear: true,
-			getCurrentTime: mockTime.getCurrentTime,
-		})
-		const onError = jest.fn()
-		myConductor.on('error', onError)
-
-		myConductor.setTimelineAndMappings([], myChannelMapping)
-		await myConductor.init()
-		await myConductor.addDevice('myViz', {
-			type: DeviceType.VIZMSE,
-			options: {
-				host: '127.0.0.1',
-				preloadAllElements: true,
-				playlistID: 'my-super-playlist-id',
-				profile: 'profile9999',
-			},
-			commandReceiver: commandReceiver0,
-		})
+		const { device, myConductor, onError, commandReceiver0 } = await setupDevice()
 		await mockTime.advanceTimeToTicks(10100)
 
-		const deviceContainer = myConductor.getDevice('myViz')
-		device = deviceContainer!.device as ThreadedClass<VizMSEDevice>
 		await device.ignoreWaitsInTests()
 
 		// Check that no commands has been scheduled:
@@ -876,48 +807,9 @@ describe('vizMSE', () => {
 
 		expect(onError).toHaveBeenCalledTimes(0)
 	})
-	test('vizMSE: Show lifecycle', async () => {
-		let device: any = undefined
-		const commandReceiver0 = jest.fn((...args) => {
-			return device._defaultCommandReceiver(...args)
-		})
-
-		const myChannelMapping0: MappingVizMSE = {
-			device: DeviceType.VIZMSE,
-			deviceId: 'myViz',
-		}
-		const myChannelMapping1: MappingVizMSE = {
-			device: DeviceType.VIZMSE,
-			deviceId: 'myViz',
-		}
-		const myChannelMapping: Mappings = {
-			viz0: myChannelMapping0,
-			viz_continue: myChannelMapping1,
-		}
-
-		const myConductor = new Conductor({
-			initializeAsClear: true,
-			getCurrentTime: mockTime.getCurrentTime,
-		})
-		const onError = jest.fn()
-		myConductor.on('error', onError)
-
-		myConductor.setTimelineAndMappings([], myChannelMapping)
-		await myConductor.init()
-		await myConductor.addDevice('myViz', {
-			type: DeviceType.VIZMSE,
-			options: {
-				host: '127.0.0.1',
-				preloadAllElements: true,
-				playlistID: 'my-super-playlist-id',
-				profile: 'profile9999',
-			},
-			commandReceiver: commandReceiver0,
-		})
+	test('vizMSE: produces initialization and cleanup commands', async () => {
+		const { device, myConductor, onError, commandReceiver0 } = await setupDevice()
 		await mockTime.advanceTimeToTicks(10100)
-
-		const deviceContainer = myConductor.getDevice('myViz')
-		device = deviceContainer!.device as ThreadedClass<VizMSEDevice>
 		await device.ignoreWaitsInTests()
 		await myConductor.devicesMakeReady(true)
 
@@ -971,30 +863,8 @@ describe('vizMSE', () => {
 			type: 'initialize_shows',
 			showIds: ['show1', 'show2'],
 		})
-		expect(rundown.cleanupShow).toHaveBeenCalledTimes(0)
-		expect(rundown.initializeShow).toHaveBeenCalledTimes(2)
-		expect(rundown.initializeShow).toHaveBeenNthCalledWith(1, 'show1')
-		expect(rundown.initializeShow).toHaveBeenNthCalledWith(2, 'show2')
-
-		rundown.initializeShow.mockClear()
-		await device.handleExpectedPlayoutItems(
-			literal<VIZMSEPlayoutItemContentInternal[]>([
-				{
-					templateName: 'bund',
-					showId: 'show2',
-				},
-				{
-					templateName: 'ident',
-					showId: 'show3',
-				},
-			])
-		)
-		await mockTime.advanceTimeToTicks(16500)
-		expect(rundown.initializeShow).toHaveBeenCalledTimes(1)
-		expect(rundown.initializeShow).toHaveBeenNthCalledWith(1, 'show2')
 
 		commandReceiver0.mockClear()
-		rundown.initializeShow.mockClear()
 		await mockTime.advanceTimeToTicks(20500)
 		expect(commandReceiver0.mock.calls.length).toEqual(1)
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
@@ -1003,20 +873,8 @@ describe('vizMSE', () => {
 			type: 'initialize_shows',
 			showIds: [],
 		})
-		expect(rundown.cleanupShow).toHaveBeenCalledTimes(0)
-		expect(rundown.initializeShow).toHaveBeenCalledTimes(0)
-
-		await device.handleExpectedPlayoutItems(
-			literal<VIZMSEPlayoutItemContentInternal[]>([
-				{
-					templateName: 'ident',
-					showId: 'show3',
-				},
-			])
-		)
 
 		commandReceiver0.mockClear()
-		rundown.initializeShow.mockClear()
 		await mockTime.advanceTimeToTicks(21500)
 		expect(commandReceiver0.mock.calls.length).toEqual(1)
 		expect(getMockCall(commandReceiver0, 0, 1)).toMatchObject({
@@ -1025,18 +883,134 @@ describe('vizMSE', () => {
 			type: 'cleanup_shows',
 			showIds: ['show3', 'show4'],
 		})
-		expect(rundown.cleanupShow).toHaveBeenCalledTimes(2)
-		expect(rundown.cleanupShow).toHaveBeenNthCalledWith(1, 'show3')
-		expect(rundown.cleanupShow).toHaveBeenNthCalledWith(2, 'show4')
+
+		commandReceiver0.mockClear()
+		await mockTime.advanceTimeToTicks(26500)
+		expect(commandReceiver0.mock.calls.length).toEqual(0)
+
+		expect(onError).toHaveBeenCalledTimes(0)
+	})
+	test('vizMSE: re-initializes show for incoming elements during TimelineObjVIZMSEInitializeShows', async () => {
+		const { device, myConductor, onError } = await setupDevice()
+		await device.ignoreWaitsInTests()
+		await myConductor.devicesMakeReady(true)
+
+		// Check that no commands has been scheduled:
+		expect(await device.queue).toHaveLength(0)
+
+		const mse = _.last(getMockMSEs()) as MSEMock
+		expect(mse).toBeTruthy()
+		expect(mse.getMockRundowns()).toHaveLength(1)
+		const rundown = _.last(mse.getMockRundowns()) as VRundownMocked
+		expect(rundown).toBeTruthy()
+
+		myConductor.setTimelineAndMappings([
+			{
+				id: 'obj0',
+				enable: {
+					start: mockTime.now + 5000, // 15100
+					duration: 5000, // 20100
+				},
+				layer: 'viz0',
+				content: {
+					deviceType: DeviceType.VIZMSE,
+					type: TimelineContentTypeVizMSE.INITIALIZE_SHOWS,
+					showIds: ['show1', 'show2'],
+				},
+			},
+		])
+
+		await device.handleExpectedPlayoutItems(
+			literal<VIZMSEPlayoutItemContentInternal[]>([
+				{
+					templateName: 'bund',
+					showId: 'show1',
+				},
+			])
+		)
+
+		await mockTime.advanceTimeToTicks(15500)
+
+		rundown.initializeShow.mockClear()
+		await device.handleExpectedPlayoutItems(
+			literal<VIZMSEPlayoutItemContentInternal[]>([
+				{
+					templateName: 'bund',
+					showId: 'show1',
+				},
+				{
+					templateName: 'bund',
+					showId: 'show2',
+				},
+				{
+					templateName: 'ident',
+					showId: 'show3',
+				},
+				{
+					templateName: 'tlf',
+					showId: 'show2',
+				},
+			])
+		)
+		await mockTime.advanceTimeToTicks(16500)
+		expect(rundown.initializeShow).toHaveBeenCalledTimes(1)
+		expect(rundown.initializeShow).toHaveBeenNthCalledWith(1, 'show2')
+
+		rundown.initializeShow.mockClear()
+		await mockTime.advanceTimeToTicks(25500)
 		expect(rundown.initializeShow).toHaveBeenCalledTimes(0)
 
+		expect(onError).toHaveBeenCalledTimes(0)
+	})
+	test('vizMSE: creates and deletes internal elements', async () => {
+		const { device, myConductor, onError } = await setupDevice()
+		await mockTime.advanceTimeToTicks(10100)
+
+		await device.ignoreWaitsInTests()
+		await myConductor.devicesMakeReady(true)
+
+		// Check that no commands has been scheduled:
+		expect(await device.queue).toHaveLength(0)
+
+		const mse = _.last(getMockMSEs()) as MSEMock
+		expect(mse).toBeTruthy()
+		expect(mse.getMockRundowns()).toHaveLength(1)
+		const rundown = _.last(mse.getMockRundowns()) as VRundownMocked
+		expect(rundown).toBeTruthy()
+
+		await mockTime.advanceTimeToTicks(20500)
+		await device.handleExpectedPlayoutItems(
+			literal<VIZMSEPlayoutItemContentInternal[]>([
+				{
+					templateName: 'bund',
+					showId: 'show2',
+					templateData: ['foo', 'bar'],
+					channel: 'my_channel',
+				},
+			])
+		)
+		expect(rundown.createElement).toHaveBeenCalledTimes(1)
+		expect(rundown.createElement).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				instanceName: 'sofieInt_bund_szi7xlRYleXD4TLRdBjduVRjx3E_',
+				showId: 'show2',
+			}),
+			'bund',
+			['foo', 'bar'],
+			'my_channel'
+		)
+
+		await device.handleExpectedPlayoutItems(literal<VIZMSEPlayoutItemContentInternal[]>([]))
+
+		await mockTime.advanceTimeToTicks(39500)
 		expect(rundown.deleteElement).toHaveBeenCalledTimes(0)
 		await mockTime.advanceTimeToTicks(41500)
 		expect(rundown.deleteElement).toHaveBeenCalledTimes(1)
 		expect(rundown.deleteElement).toHaveBeenNthCalledWith(
 			1,
 			expect.objectContaining({
-				templateName: 'bund',
+				instanceName: 'sofieInt_bund_szi7xlRYleXD4TLRdBjduVRjx3E_',
 				showId: 'show2',
 			})
 		)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1559,10 +1559,10 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@tv2media/v-connection@^5.1.2":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@tv2media/v-connection/-/v-connection-5.1.2.tgz#fb6b839fd129e496af4fa968857b632a883b91d3"
-  integrity sha512-auKVbVSksxv9SVa2T4a7/bQXzvayhNQOYqcD7L+Pa2aO0LYDGwsyy/NzR7rBKnASnG+bqAjbokFRar4awoNMJA==
+"@tv2media/v-connection@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@tv2media/v-connection/-/v-connection-6.0.0.tgz#6b9a5e7f9bb7ee929c51085b3da63f60092eb301"
+  integrity sha512-CxJDIUypXxorZaypDZ0u9IYo3pswfXGRWy9Mc5WvnJ+xi356cFFBNdQx6XAUTRON5MCbiGzSMfgipzwbd4Wmcg==
   dependencies:
     request "^2.88.2"
     request-promise-native "^1.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,6 +1849,13 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
+"@zkochan/rimraf@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@zkochan/rimraf/-/rimraf-2.1.2.tgz#84b502594321360e4a4ca864b9e6457af2f5212d"
+  integrity sha512-Lc2oK51J6aQWcLWTloobJun5ZF41BbTDdLvE+aMcexoVWFoFqvZmnZoyXR2IZk6NJEVoZW8tjgtvQLfTsmRs2Q==
+  dependencies:
+    rimraf "^3.0.2"
+
 JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -2267,6 +2274,13 @@ before-after-hook@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.2.tgz#a6e8ca41028d90ee2c24222f201c90956091613e"
   integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
+
+better-path-resolve@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/better-path-resolve/-/better-path-resolve-1.0.0.tgz#13a35a1104cdd48a7b74bf8758f96a1ee613f99d"
+  integrity sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==
+  dependencies:
+    is-windows "^1.0.0"
 
 big-integer@^1.6.51:
   version "1.6.51"
@@ -4774,7 +4788,7 @@ is-weakref@^1.0.1:
   dependencies:
     call-bind "^1.0.2"
 
-is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
@@ -7197,6 +7211,13 @@ remove-trailing-separator@^1.0.1:
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
 
+rename-overwrite@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/rename-overwrite/-/rename-overwrite-4.0.2.tgz#3a2c712150cb3b388ef82b29fce290c0b1e5c227"
+  integrity sha512-L1sgBgagVgOgb1Z6QZr1yJgSMHI4SXQqAH0l/UbeyHnLKxECvKIlyVEmBo4BqsCAZGg0SBSyjCh68lis5PgC7g==
+  dependencies:
+    "@zkochan/rimraf" "^2.1.2"
+
 repeat-element@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.4.tgz#be681520847ab58c7568ac75fbfad28ed42d39e9"
@@ -8077,6 +8098,14 @@ symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
+symlink-dir@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/symlink-dir/-/symlink-dir-5.0.1.tgz#11c65f5baa06974ec7828eda831a3754c0ea2410"
+  integrity sha512-MeXygPBopo8AmyObuCJIpXKT+mw54d2Kp6SBuxq0uXZGDkHwHDQExpSg5+TK8BA5kCGyktawu5DJG0QWYO6acw==
+  dependencies:
+    better-path-resolve "^1.0.0"
+    rename-overwrite "^4.0.0"
 
 table@^6.0.9:
   version "6.8.0"


### PR DESCRIPTION
Removes Show ID as the option of the VizMSE TSR device.
Show ID is now a property of each Internal Element and its Expected Playout Items.
Show lifecycle is no longer dependent on `makeReady` and `standDown`, instead cleanup and initialization are triggered by the new `CLEANUP_SHOWS` and `INITIALIZE_SHOWS` timeline objects.

Depends on https://github.com/tv2/v-connection/pull/34