### PR TITLE
fix: (SOF-956) lowered logging level for a apparent log call via an event.

### DIFF
--- a/packages/timeline-state-resolver/src/conductor.ts
+++ b/packages/timeline-state-resolver/src/conductor.ts
@@ -1299,7 +1299,7 @@ export class Conductor extends EventEmitter<ConductorEvents> {
 			this._statMeasureStart = 0
 			this._statMeasureReason = ''
 
-			this.emit('info', 'statReport', JSON.stringify(reportDuration))
+			this.emit('debug', 'statReport', JSON.stringify(reportDuration))
 			this.emit('statReport', reportDuration)
 		}
 	}


### PR DESCRIPTION
- Logging in conductor.statReport created ~1700ish logs a day.
	- Lowered it from Info to Debug, as it is only really useful during development, from what i can gather.
	- Was about 14% of the logs in the 24 hours file i checked.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
A small change to reduce the amount of logging in production.


* **What is the current behavior?** (You can also link to an open issue here)
Currently the changed logging line is logging with info level.


* **What is the new behavior (if this is a feature change)?**
Now the changed logging line is logging with debug level, which gets ignored in production.


* **Other information**:
