### PR TITLE
feat!: SOF-1065 human readable show names

### DIFF
--- a/packages/timeline-state-resolver-types/src/vizMSE.ts
+++ b/packages/timeline-state-resolver-types/src/vizMSE.ts
@@ -178,7 +178,7 @@ export interface TimelineObjVIZMSEInitializeShows extends TSRTimelineObjBase {
 		deviceType: DeviceType.VIZMSE
 		type: TimelineContentTypeVizMSE.INITIALIZE_SHOWS
 
-		/** IDs of the Shows to initialize */
+		/** Names of the Shows to initialize */
 		showNames: string[]
 	} & TimelineDatastoreReferencesContent
 }
@@ -187,7 +187,7 @@ export interface TimelineObjVIZMSECleanupShows extends TSRTimelineObjBase {
 		deviceType: DeviceType.VIZMSE
 		type: TimelineContentTypeVizMSE.CLEANUP_SHOWS
 
-		/** IDs of the Shows to cleanup */
+		/** Names of the Shows to cleanup */
 		showNames: string[]
 	} & TimelineDatastoreReferencesContent
 }

--- a/packages/timeline-state-resolver-types/src/vizMSE.ts
+++ b/packages/timeline-state-resolver-types/src/vizMSE.ts
@@ -18,6 +18,8 @@ export interface VizMSEOptions {
 	profile: string
 	/** Identifier of the "playlist" to send commands to */
 	playlistID?: string
+	/** Path relative to "/directory/shows", where Shows managed by Sofie are listed e.g. "SOFIE" */
+	showDirectoryPath?: string
 
 	/** Whether all elements should be preloaded or not */
 	preloadAllElements?: boolean
@@ -109,8 +111,8 @@ export interface TimelineObjVIZMSEElementInternal extends TimelineObjVIZMSEBase 
 		templateName: string
 		/** Data to be fed into the template */
 		templateData: Array<string>
-		/** Which Show to place this element in */
-		showId: string
+		/** Name of the Show to place this element in */
+		showName: string
 		/** Whether this element should have its take delayed until after an out transition has finished */
 		delayTakeAfterOutTransition?: boolean
 	} & TimelineDatastoreReferencesContent
@@ -167,8 +169,8 @@ export interface TimelineObjVIZMSEClearAllElements extends TSRTimelineObjBase {
 		/** Names of the channels to send the special clear commands to */
 		channelsToSendCommands?: string[]
 
-		/** IDs of the Show to use for taking the special template */
-		showId: string
+		/** Name of the Show to use for taking the special template */
+		showName: string
 	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjVIZMSEInitializeShows extends TSRTimelineObjBase {
@@ -177,7 +179,7 @@ export interface TimelineObjVIZMSEInitializeShows extends TSRTimelineObjBase {
 		type: TimelineContentTypeVizMSE.INITIALIZE_SHOWS
 
 		/** IDs of the Shows to initialize */
-		showIds: string[]
+		showNames: string[]
 	} & TimelineDatastoreReferencesContent
 }
 export interface TimelineObjVIZMSECleanupShows extends TSRTimelineObjBase {
@@ -185,8 +187,8 @@ export interface TimelineObjVIZMSECleanupShows extends TSRTimelineObjBase {
 		deviceType: DeviceType.VIZMSE
 		type: TimelineContentTypeVizMSE.CLEANUP_SHOWS
 
-		/** IDs of the Shows to cleanup - 'all' will cleanup all shows */
-		showIds: string[]
+		/** IDs of the Shows to cleanup */
+		showNames: string[]
 	} & TimelineDatastoreReferencesContent
 }
 
@@ -225,7 +227,7 @@ export interface VIZMSEPlayoutItemContentInternal extends VIZMSEPlayoutItemConte
 	/** Data fields of the element */
 	templateData?: string[]
 	/** Which Show to place this element in */
-	showId: string
+	showName: string
 }
 
 export interface VIZMSEPlayoutItemContentExternal extends VIZMSEPlayoutItemContentBase {

--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -57,7 +57,7 @@
 		"production"
 	],
 	"dependencies": {
-		"@tv2media/v-connection": "^7.0.2",
+		"@tv2media/v-connection": "^7.1.0",
 		"atem-connection": "2.4.0",
 		"atem-state": "^0.12.2",
 		"casparcg-connection": "^5.1.0",

--- a/packages/timeline-state-resolver/src/__mocks__/v-connection.ts
+++ b/packages/timeline-state-resolver/src/__mocks__/v-connection.ts
@@ -80,6 +80,15 @@ export class MSEMock extends EventEmitter implements MSE {
 	async listShows(): Promise<string[]> {
 		return []
 	}
+	async listShowsFromDirectory(): Promise<Map<string, string>> {
+		return new Map([
+			['SOFIE/mock_show1.show', 'UUID1'],
+			['SOFIE/mock_show2.show', 'UUID2'],
+			['SOFIE/mock_show3.show', 'UUID3'],
+			['SOFIE/mock_show4.show', 'UUID4'],
+			['mock_show1.show', 'UUID5'],
+		])
+	}
 	async getShow(showID: string): Promise<VShow> {
 		return {
 			id: 'mockshowid_' + showID,

--- a/packages/timeline-state-resolver/src/__mocks__/v-connection.ts
+++ b/packages/timeline-state-resolver/src/__mocks__/v-connection.ts
@@ -21,6 +21,20 @@ import { CommandResult } from '@tv2media/v-connection/dist/msehttp'
 import { PepResponse } from '@tv2media/v-connection/dist/peptalk'
 import _ = require('underscore')
 
+interface MockShow {
+	id: string
+	basePath: string
+	name: string
+}
+
+export const MOCK_SHOWS: MockShow[] = [
+	{ id: 'UUID1', basePath: 'SOFIE/', name: 'mock_show1' },
+	{ id: 'UUID2', basePath: 'SOFIE/', name: 'mock_show2' },
+	{ id: 'UUID3', basePath: 'SOFIE/', name: 'mock_show3' },
+	{ id: 'UUID4', basePath: 'SOFIE/', name: 'mock_show4' },
+	{ id: 'UUID5', basePath: '', name: 'mock_show1' },
+]
+
 const mockMSEs: MSEMock[] = []
 
 export const createMSE: typeof orgCreateMSE = function createMSE0(
@@ -81,13 +95,7 @@ export class MSEMock extends EventEmitter implements MSE {
 		return []
 	}
 	async listShowsFromDirectory(): Promise<Map<string, string>> {
-		return new Map([
-			['SOFIE/mock_show1.show', 'UUID1'],
-			['SOFIE/mock_show2.show', 'UUID2'],
-			['SOFIE/mock_show3.show', 'UUID3'],
-			['SOFIE/mock_show4.show', 'UUID4'],
-			['mock_show1.show', 'UUID5'],
-		])
+		return new Map(MOCK_SHOWS.map((show) => [`${show.basePath}${show.name}.show`, show.id]))
 	}
 	async getShow(showID: string): Promise<VShow> {
 		return {

--- a/packages/timeline-state-resolver/src/integrations/vizMSE/__tests__/vizMSE.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/__tests__/vizMSE.spec.ts
@@ -20,6 +20,7 @@ type MSEMock = vConnection.MSEMock
 type VRundownMocked = vConnection.VRundownMocked
 import _ = require('underscore')
 import { literal, StatusCode } from '../../../devices/device'
+import { MOCK_SHOWS } from '../../../__mocks__/v-connection'
 
 async function setupDevice() {
 	let device: any = undefined
@@ -105,7 +106,7 @@ describe('vizMSE', () => {
 					// noAutoPreloading?: boolean
 					templateName: 'myInternalElement',
 					templateData: ['line1', 'line2'],
-					showName: 'mock_show1',
+					showName: MOCK_SHOWS[0].name,
 				},
 			},
 			{
@@ -120,7 +121,7 @@ describe('vizMSE', () => {
 					type: TimelineContentTypeVizMSE.ELEMENT_INTERNAL,
 					templateName: 'myInternalElement2',
 					templateData: ['line1'],
-					showName: 'mock_show1',
+					showName: MOCK_SHOWS[0].name,
 				},
 			},
 			{
@@ -153,7 +154,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement'),
 				templateName: 'myInternalElement',
 				templateData: ['line1', 'line2'],
-				showId: 'UUID1',
+				showId: MOCK_SHOWS[0].id,
 			},
 			type: 'prepare',
 			// channelName?: string
@@ -170,7 +171,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement'),
 				templateName: 'myInternalElement',
 				templateData: ['line1', 'line2'],
-				showId: 'UUID1',
+				showId: MOCK_SHOWS[0].id,
 			},
 			type: 'take',
 		})
@@ -185,7 +186,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement2'),
 				templateName: 'myInternalElement2',
 				templateData: ['line1'],
-				showId: 'UUID1',
+				showId: MOCK_SHOWS[0].id,
 			},
 			type: 'prepare',
 		})
@@ -200,7 +201,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement2'),
 				templateName: 'myInternalElement2',
 				templateData: ['line1'],
-				showId: 'UUID1',
+				showId: MOCK_SHOWS[0].id,
 			},
 			type: 'take',
 		})
@@ -215,7 +216,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement2'),
 				templateName: 'myInternalElement2',
 				templateData: ['line1'],
-				showId: 'UUID1',
+				showId: MOCK_SHOWS[0].id,
 			},
 			type: 'continue',
 		})
@@ -230,7 +231,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement2'),
 				templateName: 'myInternalElement2',
 				templateData: ['line1'],
-				showId: 'UUID1',
+				showId: MOCK_SHOWS[0].id,
 			},
 			type: 'out',
 		})
@@ -607,7 +608,7 @@ describe('vizMSE', () => {
 					type: TimelineContentTypeVizMSE.ELEMENT_INTERNAL,
 					templateName: 'myInternalElement',
 					templateData: [],
-					showName: 'mock_show1',
+					showName: MOCK_SHOWS[0].name,
 				},
 			},
 			{
@@ -621,7 +622,7 @@ describe('vizMSE', () => {
 					deviceType: DeviceType.VIZMSE,
 					type: TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS,
 					channelsToSendCommands: ['OVL', 'FULL'],
-					showName: 'mock_show1',
+					showName: MOCK_SHOWS[0].name,
 				},
 			},
 		] as TSRTimeline)
@@ -653,7 +654,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement'),
 				templateName: 'myInternalElement',
 				templateData: [],
-				showId: 'UUID1',
+				showId: MOCK_SHOWS[0].id,
 			},
 			type: 'prepare',
 		})
@@ -664,7 +665,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement'),
 				templateName: 'myInternalElement',
 				templateData: [],
-				showId: 'UUID1',
+				showId: MOCK_SHOWS[0].id,
 			},
 			type: 'take',
 		})
@@ -692,7 +693,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement'),
 				templateName: 'myInternalElement',
 				templateData: [],
-				showId: 'UUID1',
+				showId: MOCK_SHOWS[0].id,
 			},
 			type: 'prepare',
 		})
@@ -707,7 +708,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement'),
 				templateName: 'myInternalElement',
 				templateData: [],
-				showId: 'UUID1',
+				showId: MOCK_SHOWS[0].id,
 			},
 			type: 'take',
 		})
@@ -722,7 +723,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement'),
 				templateName: 'myInternalElement',
 				templateData: [],
-				showId: 'UUID1',
+				showId: MOCK_SHOWS[0].id,
 			},
 			type: 'out',
 		})
@@ -833,7 +834,7 @@ describe('vizMSE', () => {
 				content: {
 					deviceType: DeviceType.VIZMSE,
 					type: TimelineContentTypeVizMSE.INITIALIZE_SHOWS,
-					showNames: ['mock_show1', 'mock_show2'],
+					showNames: [MOCK_SHOWS[0].name, MOCK_SHOWS[1].name],
 				},
 			},
 			{
@@ -846,7 +847,7 @@ describe('vizMSE', () => {
 				content: {
 					deviceType: DeviceType.VIZMSE,
 					type: TimelineContentTypeVizMSE.CLEANUP_SHOWS,
-					showNames: ['mock_show3', 'mock_show4'],
+					showNames: [MOCK_SHOWS[2].name, MOCK_SHOWS[3].name],
 				},
 			},
 		])
@@ -861,7 +862,7 @@ describe('vizMSE', () => {
 			timelineObjId: 'obj0',
 			time: 15100,
 			type: 'initialize_shows',
-			showIds: ['UUID1', 'UUID2'],
+			showIds: [MOCK_SHOWS[0].id, MOCK_SHOWS[1].id],
 		})
 
 		commandReceiver0.mockClear()
@@ -881,7 +882,7 @@ describe('vizMSE', () => {
 			timelineObjId: 'obj1',
 			time: 21100,
 			type: 'cleanup_shows',
-			showIds: ['UUID3', 'UUID4'],
+			showIds: [MOCK_SHOWS[2].id, MOCK_SHOWS[3].id],
 		})
 
 		commandReceiver0.mockClear()
@@ -915,7 +916,7 @@ describe('vizMSE', () => {
 				content: {
 					deviceType: DeviceType.VIZMSE,
 					type: TimelineContentTypeVizMSE.INITIALIZE_SHOWS,
-					showNames: ['mock_show1', 'mock_show2'],
+					showNames: [MOCK_SHOWS[0].name, MOCK_SHOWS[1].name],
 				},
 			},
 		])
@@ -924,7 +925,7 @@ describe('vizMSE', () => {
 			literal<VIZMSEPlayoutItemContentInternal[]>([
 				{
 					templateName: 'bund',
-					showName: 'mock_show1',
+					showName: MOCK_SHOWS[0].name,
 				},
 			])
 		)
@@ -936,25 +937,25 @@ describe('vizMSE', () => {
 			literal<VIZMSEPlayoutItemContentInternal[]>([
 				{
 					templateName: 'bund',
-					showName: 'mock_show1',
+					showName: MOCK_SHOWS[0].name,
 				},
 				{
 					templateName: 'bund',
-					showName: 'mock_show2',
+					showName: MOCK_SHOWS[1].name,
 				},
 				{
 					templateName: 'ident',
-					showName: 'mock_show3',
+					showName: MOCK_SHOWS[2].name,
 				},
 				{
 					templateName: 'tlf',
-					showName: 'mock_show2',
+					showName: MOCK_SHOWS[1].name,
 				},
 			])
 		)
 		await mockTime.advanceTimeToTicks(16500)
 		expect(rundown.initializeShow).toHaveBeenCalledTimes(1)
-		expect(rundown.initializeShow).toHaveBeenNthCalledWith(1, 'UUID2')
+		expect(rundown.initializeShow).toHaveBeenNthCalledWith(1, MOCK_SHOWS[1].id)
 
 		rundown.initializeShow.mockClear()
 		await mockTime.advanceTimeToTicks(25500)
@@ -983,7 +984,7 @@ describe('vizMSE', () => {
 			literal<VIZMSEPlayoutItemContentInternal[]>([
 				{
 					templateName: 'bund',
-					showName: 'mock_show2',
+					showName: MOCK_SHOWS[1].name,
 					templateData: ['foo', 'bar'],
 					channel: 'my_channel',
 				},
@@ -994,7 +995,7 @@ describe('vizMSE', () => {
 			1,
 			expect.objectContaining({
 				instanceName: 'sofieInt_bund_szi7xlRYleXD4TLRdBjduVRjx3E_',
-				showId: 'UUID2',
+				showId: MOCK_SHOWS[1].id,
 			}),
 			'bund',
 			['foo', 'bar'],
@@ -1011,7 +1012,7 @@ describe('vizMSE', () => {
 			1,
 			expect.objectContaining({
 				instanceName: 'sofieInt_bund_szi7xlRYleXD4TLRdBjduVRjx3E_',
-				showId: 'UUID2',
+				showId: MOCK_SHOWS[1].id,
 			})
 		)
 

--- a/packages/timeline-state-resolver/src/integrations/vizMSE/__tests__/vizMSE.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/__tests__/vizMSE.spec.ts
@@ -21,8 +21,6 @@ type VRundownMocked = vConnection.VRundownMocked
 import _ = require('underscore')
 import { literal, StatusCode } from '../../../devices/device'
 
-const SHOW_ID = '34ea2db4-ad93-42fb-b352-e49f926ed83f'
-
 async function setupDevice() {
 	let device: any = undefined
 	const commandReceiver0 = jest.fn((...args) => {
@@ -58,6 +56,7 @@ async function setupDevice() {
 			preloadAllElements: true,
 			playlistID: 'my-super-playlist-id',
 			profile: 'profile9999',
+			showDirectoryPath: 'SOFIE',
 		},
 		commandReceiver: commandReceiver0,
 	})
@@ -80,7 +79,7 @@ describe('vizMSE', () => {
 	beforeEach(() => {
 		mockTime.init()
 	})
-	test('vizMSE: Internal element', async () => {
+	test('Internal element', async () => {
 		const { device, myConductor, commandReceiver0 } = await setupDevice()
 		await mockTime.advanceTimeToTicks(10100)
 
@@ -106,7 +105,7 @@ describe('vizMSE', () => {
 					// noAutoPreloading?: boolean
 					templateName: 'myInternalElement',
 					templateData: ['line1', 'line2'],
-					showId: SHOW_ID,
+					showName: 'mock_show1',
 				},
 			},
 			{
@@ -121,7 +120,7 @@ describe('vizMSE', () => {
 					type: TimelineContentTypeVizMSE.ELEMENT_INTERNAL,
 					templateName: 'myInternalElement2',
 					templateData: ['line1'],
-					showId: SHOW_ID,
+					showName: 'mock_show1',
 				},
 			},
 			{
@@ -154,7 +153,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement'),
 				templateName: 'myInternalElement',
 				templateData: ['line1', 'line2'],
-				showId: SHOW_ID,
+				showId: 'UUID1',
 			},
 			type: 'prepare',
 			// channelName?: string
@@ -171,7 +170,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement'),
 				templateName: 'myInternalElement',
 				templateData: ['line1', 'line2'],
-				showId: SHOW_ID,
+				showId: 'UUID1',
 			},
 			type: 'take',
 		})
@@ -186,7 +185,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement2'),
 				templateName: 'myInternalElement2',
 				templateData: ['line1'],
-				showId: SHOW_ID,
+				showId: 'UUID1',
 			},
 			type: 'prepare',
 		})
@@ -201,7 +200,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement2'),
 				templateName: 'myInternalElement2',
 				templateData: ['line1'],
-				showId: SHOW_ID,
+				showId: 'UUID1',
 			},
 			type: 'take',
 		})
@@ -216,7 +215,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement2'),
 				templateName: 'myInternalElement2',
 				templateData: ['line1'],
-				showId: SHOW_ID,
+				showId: 'UUID1',
 			},
 			type: 'continue',
 		})
@@ -231,12 +230,12 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement2'),
 				templateName: 'myInternalElement2',
 				templateData: ['line1'],
-				showId: SHOW_ID,
+				showId: 'UUID1',
 			},
 			type: 'out',
 		})
 	})
-	test('vizMSE: External/Pilot element', async () => {
+	test('External/Pilot element', async () => {
 		const { device, myConductor, onError, commandReceiver0 } = await setupDevice()
 		await mockTime.advanceTimeToTicks(10100)
 
@@ -470,7 +469,7 @@ describe('vizMSE', () => {
 
 		expect(onError).toHaveBeenCalledTimes(0)
 	})
-	test('vizMSE: bad init options & basic functionality', async () => {
+	test('bad init options & basic functionality', async () => {
 		const myConductor = new Conductor({
 			multiThreadedResolver: false,
 			getCurrentTime: mockTime.getCurrentTime,
@@ -550,7 +549,7 @@ describe('vizMSE', () => {
 		expect(onError).toHaveBeenCalledTimes(0)
 		expect(onWarning).toHaveBeenCalledTimes(0)
 	})
-	test('vizMSE: clear all elements', async () => {
+	test('clear all elements', async () => {
 		const commandReceiver0 = jest.fn(async () => {
 			return Promise.resolve()
 		})
@@ -582,6 +581,7 @@ describe('vizMSE', () => {
 				profile: 'profile9999',
 				clearAllTemplateName: 'clear_all_of_them',
 				clearAllCommands: ['RENDERER*FRONT_LAYER SET_OBJECT ', 'RENDERER SET_OBJECT '],
+				showDirectoryPath: 'SOFIE',
 			},
 			commandReceiver: commandReceiver0,
 		})
@@ -607,7 +607,7 @@ describe('vizMSE', () => {
 					type: TimelineContentTypeVizMSE.ELEMENT_INTERNAL,
 					templateName: 'myInternalElement',
 					templateData: [],
-					showId: SHOW_ID,
+					showName: 'mock_show1',
 				},
 			},
 			{
@@ -621,7 +621,7 @@ describe('vizMSE', () => {
 					deviceType: DeviceType.VIZMSE,
 					type: TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS,
 					channelsToSendCommands: ['OVL', 'FULL'],
-					showId: SHOW_ID,
+					showName: 'mock_show1',
 				},
 			},
 		] as TSRTimeline)
@@ -653,7 +653,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement'),
 				templateName: 'myInternalElement',
 				templateData: [],
-				showId: SHOW_ID,
+				showId: 'UUID1',
 			},
 			type: 'prepare',
 		})
@@ -664,7 +664,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement'),
 				templateName: 'myInternalElement',
 				templateData: [],
-				showId: SHOW_ID,
+				showId: 'UUID1',
 			},
 			type: 'take',
 		})
@@ -692,7 +692,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement'),
 				templateName: 'myInternalElement',
 				templateData: [],
-				showId: SHOW_ID,
+				showId: 'UUID1',
 			},
 			type: 'prepare',
 		})
@@ -707,7 +707,7 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement'),
 				templateName: 'myInternalElement',
 				templateData: [],
-				showId: SHOW_ID,
+				showId: 'UUID1',
 			},
 			type: 'take',
 		})
@@ -722,12 +722,12 @@ describe('vizMSE', () => {
 				instanceName: expect.stringContaining('myInternalElement'),
 				templateName: 'myInternalElement',
 				templateData: [],
-				showId: SHOW_ID,
+				showId: 'UUID1',
 			},
 			type: 'out',
 		})
 	})
-	test('vizMSE: Delayed External/Pilot element', async () => {
+	test('Delayed External/Pilot element', async () => {
 		const { device, myConductor, onError, commandReceiver0 } = await setupDevice()
 		await mockTime.advanceTimeToTicks(10100)
 
@@ -807,7 +807,7 @@ describe('vizMSE', () => {
 
 		expect(onError).toHaveBeenCalledTimes(0)
 	})
-	test('vizMSE: produces initialization and cleanup commands', async () => {
+	test('produces initialization and cleanup commands', async () => {
 		const { device, myConductor, onError, commandReceiver0 } = await setupDevice()
 		await mockTime.advanceTimeToTicks(10100)
 		await device.ignoreWaitsInTests()
@@ -833,7 +833,7 @@ describe('vizMSE', () => {
 				content: {
 					deviceType: DeviceType.VIZMSE,
 					type: TimelineContentTypeVizMSE.INITIALIZE_SHOWS,
-					showIds: ['show1', 'show2'],
+					showNames: ['mock_show1', 'mock_show2'],
 				},
 			},
 			{
@@ -846,7 +846,7 @@ describe('vizMSE', () => {
 				content: {
 					deviceType: DeviceType.VIZMSE,
 					type: TimelineContentTypeVizMSE.CLEANUP_SHOWS,
-					showIds: ['show3', 'show4'],
+					showNames: ['mock_show3', 'mock_show4'],
 				},
 			},
 		])
@@ -861,7 +861,7 @@ describe('vizMSE', () => {
 			timelineObjId: 'obj0',
 			time: 15100,
 			type: 'initialize_shows',
-			showIds: ['show1', 'show2'],
+			showIds: ['UUID1', 'UUID2'],
 		})
 
 		commandReceiver0.mockClear()
@@ -881,7 +881,7 @@ describe('vizMSE', () => {
 			timelineObjId: 'obj1',
 			time: 21100,
 			type: 'cleanup_shows',
-			showIds: ['show3', 'show4'],
+			showIds: ['UUID3', 'UUID4'],
 		})
 
 		commandReceiver0.mockClear()
@@ -890,7 +890,7 @@ describe('vizMSE', () => {
 
 		expect(onError).toHaveBeenCalledTimes(0)
 	})
-	test('vizMSE: re-initializes show for incoming elements during TimelineObjVIZMSEInitializeShows', async () => {
+	test('re-initializes show for incoming elements during TimelineObjVIZMSEInitializeShows', async () => {
 		const { device, myConductor, onError } = await setupDevice()
 		await device.ignoreWaitsInTests()
 		await myConductor.devicesMakeReady(true)
@@ -915,7 +915,7 @@ describe('vizMSE', () => {
 				content: {
 					deviceType: DeviceType.VIZMSE,
 					type: TimelineContentTypeVizMSE.INITIALIZE_SHOWS,
-					showIds: ['show1', 'show2'],
+					showNames: ['mock_show1', 'mock_show2'],
 				},
 			},
 		])
@@ -924,7 +924,7 @@ describe('vizMSE', () => {
 			literal<VIZMSEPlayoutItemContentInternal[]>([
 				{
 					templateName: 'bund',
-					showId: 'show1',
+					showName: 'mock_show1',
 				},
 			])
 		)
@@ -936,25 +936,25 @@ describe('vizMSE', () => {
 			literal<VIZMSEPlayoutItemContentInternal[]>([
 				{
 					templateName: 'bund',
-					showId: 'show1',
+					showName: 'mock_show1',
 				},
 				{
 					templateName: 'bund',
-					showId: 'show2',
+					showName: 'mock_show2',
 				},
 				{
 					templateName: 'ident',
-					showId: 'show3',
+					showName: 'mock_show3',
 				},
 				{
 					templateName: 'tlf',
-					showId: 'show2',
+					showName: 'mock_show2',
 				},
 			])
 		)
 		await mockTime.advanceTimeToTicks(16500)
 		expect(rundown.initializeShow).toHaveBeenCalledTimes(1)
-		expect(rundown.initializeShow).toHaveBeenNthCalledWith(1, 'show2')
+		expect(rundown.initializeShow).toHaveBeenNthCalledWith(1, 'UUID2')
 
 		rundown.initializeShow.mockClear()
 		await mockTime.advanceTimeToTicks(25500)
@@ -962,7 +962,7 @@ describe('vizMSE', () => {
 
 		expect(onError).toHaveBeenCalledTimes(0)
 	})
-	test('vizMSE: creates and deletes internal elements', async () => {
+	test('creates and deletes internal elements', async () => {
 		const { device, myConductor, onError } = await setupDevice()
 		await mockTime.advanceTimeToTicks(10100)
 
@@ -983,7 +983,7 @@ describe('vizMSE', () => {
 			literal<VIZMSEPlayoutItemContentInternal[]>([
 				{
 					templateName: 'bund',
-					showId: 'show2',
+					showName: 'mock_show2',
 					templateData: ['foo', 'bar'],
 					channel: 'my_channel',
 				},
@@ -994,7 +994,7 @@ describe('vizMSE', () => {
 			1,
 			expect.objectContaining({
 				instanceName: 'sofieInt_bund_szi7xlRYleXD4TLRdBjduVRjx3E_',
-				showId: 'show2',
+				showId: 'UUID2',
 			}),
 			'bund',
 			['foo', 'bar'],
@@ -1011,7 +1011,7 @@ describe('vizMSE', () => {
 			1,
 			expect.objectContaining({
 				instanceName: 'sofieInt_bund_szi7xlRYleXD4TLRdBjduVRjx3E_',
-				showId: 'show2',
+				showId: 'UUID2',
 			})
 		)
 

--- a/packages/timeline-state-resolver/src/integrations/vizMSE/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/index.ts
@@ -1,5 +1,4 @@
 import * as _ from 'underscore'
-import { EventEmitter } from 'events'
 import { CommandWithContext, DeviceStatus, DeviceWithState, literal, StatusCode } from './../../devices/device'
 
 import {
@@ -14,53 +13,56 @@ import {
 	TimelineObjVIZMSEElementInternal,
 	TimelineObjVIZMSEElementPilot,
 	VizMSEOptions,
-	VIZMSEOutTransition,
-	VIZMSEPlayoutItemContent,
-	VIZMSEPlayoutItemContentExternal,
-	VIZMSEPlayoutItemContentInternal,
 	VIZMSETransitionType,
 } from 'timeline-state-resolver-types'
 
 import { ResolvedTimelineObjectInstance, TimelineState } from 'superfly-timeline'
 
-import { createMSE, ExternalElement, InternalElement, MSE, VElement, VRundown } from '@tv2media/v-connection'
+import { createMSE, MSE } from '@tv2media/v-connection'
 
 import { DoOnTime, SendMode } from '../../devices/doOnTime'
 
-import * as crypto from 'crypto'
-import * as net from 'net'
 import { ExpectedPlayoutItem } from '../../expectedPlayoutItems'
-import * as request from 'request'
-import { deferAsync, endTrace, startTrace } from '../../lib'
+import { endTrace, startTrace } from '../../lib'
 import { HTTPClientError, HTTPServerError } from '@tv2media/v-connection/dist/msehttp'
+import { VizMSEManager } from './vizMSEManager'
+import {
+	VizMSECommand,
+	VizMSEState,
+	VizMSEStateLayerLoadAllElements,
+	VizMSEStateLayerContinue,
+	VizMSEStateLayerInitializeShows,
+	VizMSEStateLayerCleanupShows,
+	VizMSEStateLayerConcept,
+	VizMSEStateLayer,
+	VizMSEStateLayerInternal,
+	VizMSEStateLayerPilot,
+	VizMSECommandType,
+	VizMSECommandLoadAllElements,
+	VizMSECommandElementBase,
+	VizMSECommandContinue,
+	VizMSECommandContinueReverse,
+	VizMSECommandInitializeShows,
+	VizMSECommandCleanupShows,
+	VizMSECommandSetConcept,
+	VizMSECommandPrepare,
+	VizMSECommandCue,
+	VizMSECommandTake,
+	VizMSECommandTakeOut,
+	VizMSECommandClearAllElements,
+	VizMSECommandClearAllEngines,
+} from './types'
 
 /** The ideal time to prepare elements before going on air */
 const IDEAL_PREPARE_TIME = 1000
 /** Minimum time to wait after preparing elements */
 const PREPARE_TIME_WAIT = 50
-/** Minimum time to wait before removing an element after an expectedPlayoutItem has been removed */
-const DELETE_TIME_WAIT = 20 * 1000
-
-// How often to check / preload elements
-const MONITOR_INTERVAL = 5 * 1000
-
-// How long to wait after any action (takes, cues, etc) before trying to cue for preloading
-const SAFE_PRELOAD_TIME = 2000
-
-// How long to wait before retrying to ping the MSE when initializing the rundown, after a failed attempt
-const INIT_RETRY_INTERVAL = 3000
-
-export function getHash(str: string): string {
-	const hash = crypto.createHash('sha1')
-	return hash.update(str).digest('base64').replace(/[+/=]/g, '_') // remove +/= from strings, because they cause troubles
-}
 
 export interface DeviceOptionsVizMSEInternal extends DeviceOptionsVizMSE {
 	commandReceiver?: CommandReceiver
 }
 export type CommandReceiver = (time: number, cmd: VizMSECommand, context: string, timelineObjId: string) => Promise<any>
-export type Engine = { name: string; channel?: string; host: string; port: number }
-type EngineStatus = Engine & { alive: boolean }
+
 /**
  * This class is used to interface with a vizRT Media Sequence Editor, through the v-connection library.
  * It features playing both "internal" graphics element and vizPilot elements.
@@ -118,6 +120,7 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 			this._initOptions.purgeUnknownElements ?? false,
 			this._initOptions.autoLoadInternalElements ?? false,
 			this._initOptions.engineRestPort,
+			this._initOptions.showDirectoryPath ?? '',
 			initOptions.profile,
 			initOptions.playlistID
 		)
@@ -266,14 +269,23 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 								contentType: TimelineContentTypeVizMSE.LOAD_ALL_ELEMENTS,
 							})
 							break
-						case TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS:
+						case TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS: {
 							// Special case: clear all graphics:
+							const showId = this._vizmseManager?.resolveShowNameToId(l.content.showName)
+							if (!showId) {
+								this.emit(
+									'warning',
+									`convertStateToVizMSE: Unable to find Show Id for Clear-All template and Show Name "${l.content.showName}"`
+								)
+								break
+							}
 							state.isClearAll = {
 								timelineObjId: l.id,
-								showId: l.content.showId,
+								showId,
 								channelsToSendCommands: l.content.channelsToSendCommands,
 							}
 							break
+						}
 						case TimelineContentTypeVizMSE.CONTINUE:
 							state.layer[layerName] = literal<VizMSEStateLayerContinue>({
 								timelineObjId: l.id,
@@ -286,14 +298,18 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 							state.layer[layerName] = literal<VizMSEStateLayerInitializeShows>({
 								timelineObjId: l.id,
 								contentType: TimelineContentTypeVizMSE.INITIALIZE_SHOWS,
-								showIds: l.content.showIds,
+								showIds: _.compact(
+									l.content.showNames.map((showName) => this._vizmseManager?.resolveShowNameToId(showName))
+								),
 							})
 							break
 						case TimelineContentTypeVizMSE.CLEANUP_SHOWS:
 							state.layer[layerName] = literal<VizMSEStateLayerCleanupShows>({
 								timelineObjId: l.id,
 								contentType: TimelineContentTypeVizMSE.CLEANUP_SHOWS,
-								showIds: l.content.showIds,
+								showIds: _.compact(
+									l.content.showNames.map((showName) => this._vizmseManager?.resolveShowNameToId(showName))
+								),
 							})
 							break
 						case TimelineContentTypeVizMSE.CONCEPT:
@@ -304,7 +320,7 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 							})
 							break
 						default: {
-							const stateLayer = content2StateLayer(l.id, l.content as any)
+							const stateLayer = this._content2StateLayer(l.id, l.content as any)
 							if (stateLayer) {
 								if (isLookahead) stateLayer.lookahead = true
 
@@ -344,6 +360,50 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 		})
 
 		return state
+	}
+
+	private _content2StateLayer(
+		timelineObjId: string,
+		content: TimelineObjVIZMSEElementInternal['content'] | TimelineObjVIZMSEElementPilot['content']
+	): VizMSEStateLayer | undefined {
+		if (content.type === TimelineContentTypeVizMSE.ELEMENT_INTERNAL) {
+			const showId = this._vizmseManager?.resolveShowNameToId(content.showName)
+			if (!showId) {
+				this.emit(
+					'warning',
+					`_content2StateLayer: Unable to find Show Id for template "${content.templateName}" and Show Name "${content.showName}"`
+				)
+				return undefined
+			}
+			const o: VizMSEStateLayerInternal = {
+				timelineObjId: timelineObjId,
+				contentType: TimelineContentTypeVizMSE.ELEMENT_INTERNAL,
+				continueStep: content.continueStep,
+				cue: content.cue,
+				outTransition: content.outTransition,
+
+				templateName: content.templateName,
+				templateData: content.templateData,
+				channelName: content.channelName,
+				delayTakeAfterOutTransition: content.delayTakeAfterOutTransition,
+				showId,
+			}
+			return o
+		} else if (content.type === TimelineContentTypeVizMSE.ELEMENT_PILOT) {
+			const o: VizMSEStateLayerPilot = {
+				timelineObjId: timelineObjId,
+				contentType: TimelineContentTypeVizMSE.ELEMENT_PILOT,
+				continueStep: content.continueStep,
+				cue: content.cue,
+				outTransition: content.outTransition,
+
+				templateVcpId: content.templateVcpId,
+				channelName: content.channelName,
+				delayTakeAfterOutTransition: content.delayTakeAfterOutTransition,
+			}
+			return o
+		}
+		return undefined
 	}
 
 	/**
@@ -779,50 +839,49 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 		this.emitDebug(cwc)
 
 		try {
-			if (this._vizmseManager) {
-				switch (cmd.type) {
-					case VizMSECommandType.PREPARE_ELEMENT:
-						await this._vizmseManager.prepareElement(cmd)
-						break
-					case VizMSECommandType.CUE_ELEMENT:
-						await this._vizmseManager.cueElement(cmd)
-						break
-					case VizMSECommandType.TAKE_ELEMENT:
-						await this._vizmseManager.takeElement(cmd)
-						break
-					case VizMSECommandType.TAKEOUT_ELEMENT:
-						await this._vizmseManager.takeoutElement(cmd)
-						break
-					case VizMSECommandType.CONTINUE_ELEMENT:
-						await this._vizmseManager.continueElement(cmd)
-						break
-					case VizMSECommandType.CONTINUE_ELEMENT_REVERSE:
-						await this._vizmseManager.continueElementReverse(cmd)
-						break
-					case VizMSECommandType.LOAD_ALL_ELEMENTS:
-						await this._vizmseManager.loadAllElements(cmd)
-						break
-					case VizMSECommandType.CLEAR_ALL_ELEMENTS:
-						await this._vizmseManager.clearAll(cmd)
-						break
-					case VizMSECommandType.CLEAR_ALL_ENGINES:
-						await this._vizmseManager.clearEngines(cmd)
-						break
-					case VizMSECommandType.SET_CONCEPT:
-						await this._vizmseManager.setConcept(cmd)
-						break
-					case VizMSECommandType.INITIALIZE_SHOWS:
-						await this._vizmseManager.initializeShows(cmd)
-						break
-					case VizMSECommandType.CLEANUP_SHOWS:
-						await this._vizmseManager.cleanupShows(cmd)
-						break
-					default:
-						// @ts-ignore never
-						throw new Error(`Unsupported command type "${cmd.type}"`)
-				}
-			} else {
+			if (!this._vizmseManager) {
 				throw new Error(`Not initialized yet`)
+			}
+			switch (cmd.type) {
+				case VizMSECommandType.PREPARE_ELEMENT:
+					await this._vizmseManager.prepareElement(cmd)
+					break
+				case VizMSECommandType.CUE_ELEMENT:
+					await this._vizmseManager.cueElement(cmd)
+					break
+				case VizMSECommandType.TAKE_ELEMENT:
+					await this._vizmseManager.takeElement(cmd)
+					break
+				case VizMSECommandType.TAKEOUT_ELEMENT:
+					await this._vizmseManager.takeoutElement(cmd)
+					break
+				case VizMSECommandType.CONTINUE_ELEMENT:
+					await this._vizmseManager.continueElement(cmd)
+					break
+				case VizMSECommandType.CONTINUE_ELEMENT_REVERSE:
+					await this._vizmseManager.continueElementReverse(cmd)
+					break
+				case VizMSECommandType.LOAD_ALL_ELEMENTS:
+					await this._vizmseManager.loadAllElements(cmd)
+					break
+				case VizMSECommandType.CLEAR_ALL_ELEMENTS:
+					await this._vizmseManager.clearAll(cmd)
+					break
+				case VizMSECommandType.CLEAR_ALL_ENGINES:
+					await this._vizmseManager.clearEngines(cmd)
+					break
+				case VizMSECommandType.SET_CONCEPT:
+					await this._vizmseManager.setConcept(cmd)
+					break
+				case VizMSECommandType.INITIALIZE_SHOWS:
+					await this._vizmseManager.initializeShows(cmd)
+					break
+				case VizMSECommandType.CLEANUP_SHOWS:
+					await this._vizmseManager.cleanupShows(cmd)
+					break
+				default:
+					// @ts-ignore never
+					throw new Error(`Unsupported command type "${cmd.type}"`)
 			}
 		} catch (e) {
 			const error = e as Error
@@ -844,1498 +903,5 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 	public ignoreWaitsInTests() {
 		if (!this._vizmseManager) throw new Error('_vizmseManager not set')
 		this._vizmseManager.ignoreAllWaits = true
-	}
-}
-class VizMSEManager extends EventEmitter {
-	public initialized = false
-	public notLoadedCount = 0
-	public loadingCount = 0
-	public enginesDisconnected: Array<string> = []
-
-	private _rundown: VRundown | undefined
-	private _elementCache: { [hash: string]: CachedVElement } = {}
-	private _expectedPlayoutItems: Array<ExpectedPlayoutItem> = []
-	private _monitorAndLoadElementsTimeout?: NodeJS.Timer
-	private _monitorMSEConnectionTimeout?: NodeJS.Timer
-	private _lastTimeCommandSent = 0
-	private _hasActiveRundown = false
-	private _getRundownPromise?: Promise<VRundown>
-	private _mseConnected: boolean | undefined = undefined // undefined: first connection not established yet
-	private _msePingConnected = false
-	private _loadingAllElements = false
-	private _waitWithLayers: {
-		[portId: string]: Function[]
-	} = {}
-	public ignoreAllWaits = false // Only to be used in tests
-	private _terminated = false
-	private _activeRundownPlaylistId: string | undefined
-	private _preloadedRundownPlaylistId: string | undefined
-	private _updateAfterReconnect = false
-	private _initializedShows = new Set<string>()
-
-	public get activeRundownPlaylistId() {
-		return this._activeRundownPlaylistId
-	}
-
-	constructor(
-		private _parentVizMSEDevice: VizMSEDevice,
-		private _vizMSE: MSE,
-		public preloadAllElements: boolean,
-		public onlyPreloadActivePlaylist: boolean,
-		public purgeUnknownElements: boolean,
-		public autoLoadInternalElements: boolean,
-		public engineRestPort: number | undefined,
-		private _profile: string,
-		private _playlistID?: string
-	) {
-		super()
-	}
-	/**
-	 * Initialize the Rundown in MSE.
-	 * Our approach is to create a single rundown on initialization, and then use only that for later control.
-	 */
-	public async initializeRundown(activeRundownPlaylistId: string | undefined): Promise<void> {
-		this._vizMSE.on('connected', () => this.mseConnectionChanged(true))
-		this._vizMSE.on('disconnected', () => this.mseConnectionChanged(false))
-		this._vizMSE.on('warning', (message: string) => this.emit('warning', 'v-connection: ' + message))
-		this._activeRundownPlaylistId = activeRundownPlaylistId
-		this._preloadedRundownPlaylistId = this.onlyPreloadActivePlaylist ? activeRundownPlaylistId : undefined
-
-		if (activeRundownPlaylistId) {
-			this.emit('debug', `VizMSE: already active playlist: ${this._preloadedRundownPlaylistId}`)
-		}
-
-		const initializeRundownInner = async () => {
-			try {
-				// Perform a ping, to ensure we are connected properly
-				await this._vizMSE.ping()
-				this._msePingConnected = true
-				this.mseConnectionChanged(true)
-
-				// Setup the rundown used by this device:
-				const rundown = await this._getRundown()
-
-				if (!rundown) throw new Error(`VizMSEManager: Unable to create rundown!`)
-			} catch (e) {
-				this.emit('debug', `VizMSE: initializeRundownInner ${e}`)
-				setTimeout(() => {
-					deferAsync(
-						async () => initializeRundownInner(),
-						(_e) => {
-							// ignore error
-						}
-					)
-				}, INIT_RETRY_INTERVAL)
-				return
-			}
-
-			// const profile = await this._vizMSE.getProfile('sofie') // TODO: Figure out if this is needed
-
-			this._setMonitorLoadedElementsTimeout()
-			this._setMonitorConnectionTimeout()
-
-			this.initialized = true
-		}
-
-		await initializeRundownInner()
-	}
-	/**
-	 * Close connections and die
-	 */
-	public async terminate() {
-		this._terminated = true
-		if (this._monitorAndLoadElementsTimeout) {
-			clearTimeout(this._monitorAndLoadElementsTimeout)
-		}
-		if (this._monitorMSEConnectionTimeout) {
-			clearTimeout(this._monitorMSEConnectionTimeout)
-		}
-		if (this._vizMSE) {
-			await this._vizMSE.close()
-		}
-	}
-	/**
-	 * Set the collection of expectedPlayoutItems.
-	 * These will be monitored and can be triggered to pre-load.
-	 */
-	public setExpectedPlayoutItems(expectedPlayoutItems: Array<ExpectedPlayoutItem>) {
-		this.emit('debug', 'VIZDEBUG: setExpectedPlayoutItems called')
-		if (this.preloadAllElements) {
-			this.emit('debug', 'VIZDEBUG: preload elements allowed')
-			this._expectedPlayoutItems = expectedPlayoutItems
-			this._prepareAndGetExpectedPlayoutItems() // Calling this in order to trigger creation of all elements
-				.then(async (hashesAndItems) => {
-					if (this._rundown && this._hasActiveRundown) {
-						this.emit('debug', 'VIZDEBUG: auto load internal elements...')
-						await this.updateElementsLoadedStatus()
-
-						const elementHashesToDelete: string[] = []
-						// When a new element is added, we'll trigger a show init:
-						const showIdsToInitialize = new Set<string>()
-						_.each(this._elementCache, (element) => {
-							if (isVizMSEPlayoutItemContentInternalInstance(element.content)) {
-								if (!element.isLoaded && !element.requestedLoading) {
-									this.emit('debug', `Element "${this._getElementReference(element.element)}" is not loaded`)
-									if (this.autoLoadInternalElements || this._initializedShows.has(element.content.showId)) {
-										showIdsToInitialize.add(element.content.showId)
-										element.requestedLoading = true
-									}
-								}
-							}
-							if (!hashesAndItems[element.hash] && !element.toDelete) {
-								elementHashesToDelete.push(element.hash)
-								this._elementCache[element.hash].toDelete = true
-							}
-						})
-						const uniqueShowIds = Array.from(showIdsToInitialize)
-						await this._initializeShows(uniqueShowIds)
-
-						setTimeout(() => {
-							Promise.all(
-								elementHashesToDelete.map(async (elementHash) => {
-									const element = this._elementCache[elementHash]
-									if (element?.toDelete) {
-										await this._deleteElement(element.content)
-										delete this._elementCache[elementHash]
-									}
-								})
-							).catch((error) => this.emit('error', error))
-						}, DELETE_TIME_WAIT)
-					}
-				})
-				.catch((error) => this.emit('error', error))
-		}
-	}
-	/**
-	 * Activate the rundown.
-	 * This causes the MSE rundown to activate, which must be done before using it.
-	 * Doing this will make MSE start loading things onto the vizEngine etc.
-	 */
-	public async activate(rundownPlaylistId: string | undefined): Promise<void> {
-		this._preloadedRundownPlaylistId = this.onlyPreloadActivePlaylist ? rundownPlaylistId : undefined
-		let loadTwice = false
-		if (!rundownPlaylistId || this._activeRundownPlaylistId !== rundownPlaylistId) {
-			this._triggerCommandSent()
-			const rundown = await this._getRundown()
-
-			// clear any existing elements from the existing rundown
-			try {
-				this.emit('debug', `VizMSE: purging rundown`)
-				const elementsToKeep = this._expectedPlayoutItems
-					.filter((item) => !!item.baseline)
-					.map((playoutItem) => VizMSEManager.getPlayoutItemContent(playoutItem))
-					.filter(isVizMSEPlayoutItemContentExternalInstance)
-
-				await rundown.purgeExternalElements(elementsToKeep)
-			} catch (error) {
-				this.emit('error', error)
-			}
-			this._clearCache()
-			this._clearMediaObjects()
-			loadTwice = true
-		}
-
-		this._triggerCommandSent()
-		this._triggerLoadAllElements(loadTwice)
-			.then(async () => {
-				this._triggerCommandSent()
-				this._activeRundownPlaylistId = rundownPlaylistId
-				this._hasActiveRundown = true
-
-				if (this.purgeUnknownElements) {
-					const rundown = await this._getRundown()
-					const elementsInRundown = await rundown.listExternalElements()
-					const hashesAndItems = await this._prepareAndGetExpectedPlayoutItems()
-
-					for (const element of elementsInRundown) {
-						// Check if that element is in our expectedPlayoutItems list
-						if (!hashesAndItems[VizMSEManager._getElementHash(element)]) {
-							// The element in the Viz-rundown seems to be unknown to us
-							await rundown.deleteElement(element)
-						}
-					}
-				}
-			})
-			.catch((e) => {
-				this.emit('error', e)
-			})
-	}
-	/**
-	 * Deactivate the MSE rundown.
-	 * This causes the MSE to stand down and clear the vizEngines of any loaded graphics.
-	 */
-	public async deactivate(): Promise<void> {
-		const rundown = await this._getRundown()
-		this._triggerCommandSent()
-		await rundown.deactivate()
-		this._triggerCommandSent()
-		this.standDownActiveRundown()
-		this._clearMediaObjects()
-	}
-	public standDownActiveRundown(): void {
-		this._hasActiveRundown = false
-		this._activeRundownPlaylistId = undefined
-	}
-	private _clearMediaObjects(): void {
-		this.emit('clearMediaObjects')
-	}
-	/**
-	 * Prepare an element
-	 * This creates the element and is intended to be called a little time ahead of Takeing the element.
-	 */
-	public async prepareElement(cmd: VizMSECommandPrepare): Promise<void> {
-		this.logCommand(cmd, 'prepare')
-		this._triggerCommandSent()
-		await this._checkPrepareElement(cmd.content, true)
-		this._triggerCommandSent()
-	}
-	/**
-	 * Cue:ing an element: Load and play the first frame of a graphic
-	 */
-	public async cueElement(cmd: VizMSECommandCue): Promise<void> {
-		const rundown = await this._getRundown()
-
-		await this._checkPrepareElement(cmd.content)
-
-		await this._checkElementExists(cmd)
-		await this._handleRetry(async () => {
-			this.logCommand(cmd, 'cue')
-			return rundown.cue(cmd.content)
-		})
-	}
-
-	logCommand(cmd: VizMSECommandElementBase, commandName: string) {
-		const content = cmd.content
-		if (isVizMSEPlayoutItemContentInternalInstance(content)) {
-			this.emit('debug', `VizMSE: ${commandName} "${content.instanceName}" in show "${content.showId}"`)
-		} else {
-			this.emit('debug', `VizMSE: ${commandName} "${content.vcpid}" on channel "${content.channel}"`)
-		}
-	}
-
-	/**
-	 * Take an element: Load and Play a graphic element, run in-animatinos etc
-	 */
-	public async takeElement(cmd: VizMSECommandTake): Promise<void> {
-		const rundown = await this._getRundown()
-
-		await this._checkPrepareElement(cmd.content)
-
-		if (cmd.transition) {
-			if (cmd.transition.type === VIZMSETransitionType.DELAY) {
-				if (await this.waitWithLayer(cmd.layerId || '__default', cmd.transition.delay)) {
-					// at this point, the wait aws aborted by someone else. Do nothing then.
-					return
-				}
-			}
-		}
-
-		await this._checkElementExists(cmd)
-		await this._handleRetry(async () => {
-			this.logCommand(cmd, 'take')
-			return rundown.take(cmd.content)
-		})
-	}
-	/**
-	 * Take out: Animate out a graphic element
-	 */
-	public async takeoutElement(cmd: VizMSECommandTakeOut): Promise<void> {
-		const rundown = await this._getRundown()
-
-		if (cmd.transition) {
-			if (cmd.transition.type === VIZMSETransitionType.DELAY) {
-				if (await this.waitWithLayer(cmd.layerId || '__default', cmd.transition.delay)) {
-					// at this point, the wait aws aborted by someone else. Do nothing then.
-					return
-				}
-			}
-		}
-
-		await this._checkPrepareElement(cmd.content)
-
-		await this._checkElementExists(cmd)
-		await this._handleRetry(async () => {
-			this.logCommand(cmd, 'out')
-			return rundown.out(cmd.content)
-		})
-	}
-	/**
-	 * Continue: Cause the graphic element to step forward, if it has multiple states
-	 */
-	public async continueElement(cmd: VizMSECommandContinue): Promise<void> {
-		const rundown = await this._getRundown()
-
-		await this._checkPrepareElement(cmd.content)
-
-		await this._checkElementExists(cmd)
-		await this._handleRetry(async () => {
-			this.logCommand(cmd, 'continue')
-			return rundown.continue(cmd.content)
-		})
-	}
-	/**
-	 * Continue-reverse: Cause the graphic element to step backwards, if it has multiple states
-	 */
-	public async continueElementReverse(cmd: VizMSECommandContinueReverse): Promise<void> {
-		const rundown = await this._getRundown()
-
-		await this._checkPrepareElement(cmd.content)
-
-		await this._checkElementExists(cmd)
-		await this._handleRetry(async () => {
-			this.logCommand(cmd, 'continue reverse')
-			return rundown.continueReverse(cmd.content)
-		})
-	}
-	/**
-	 * Special: trigger a template which clears all templates on the output
-	 */
-	public async clearAll(cmd: VizMSECommandClearAllElements): Promise<void> {
-		const rundown = await this._getRundown()
-
-		const template: VizMSEStateLayerInternal = {
-			timelineObjId: cmd.timelineObjId,
-			contentType: TimelineContentTypeVizMSE.ELEMENT_INTERNAL,
-			templateName: cmd.templateName,
-			templateData: [],
-			showId: cmd.showId,
-		}
-		// Start playing special element:
-		const cmdTake: VizMSECommandTake = {
-			time: cmd.time,
-			type: VizMSECommandType.TAKE_ELEMENT,
-			timelineObjId: template.timelineObjId,
-			content: VizMSEManager.getPlayoutItemContentFromLayer(template),
-		}
-
-		await this._checkPrepareElement(cmdTake.content)
-
-		await this._checkElementExists(cmdTake)
-		await this._handleRetry(async () => {
-			this.logCommand(cmdTake, 'clearAll take')
-			return rundown.take(cmdTake.content)
-		})
-	}
-	/**
-	 * Special: send commands to Viz Engines in order to clear them
-	 */
-	public async clearEngines(cmd: VizMSECommandClearAllEngines): Promise<void> {
-		try {
-			const engines = await this._getEngines()
-			const enginesToClear = this._filterEnginesToClear(engines, cmd.channels)
-			enginesToClear.forEach((engine) => {
-				const sender = new VizEngineTcpSender(engine.port, engine.host)
-				sender.on('warning', (w) => this.emit('warning', `clearEngines: ${w}`))
-				sender.on('error', (e) => this.emit('error', `clearEngines: ${e}`))
-				sender.send(cmd.commands)
-			})
-		} catch (e) {
-			this.emit('warning', `Sending Clear-all command failed ${e}`)
-		}
-	}
-	private async _getEngines(): Promise<Engine[]> {
-		const profile = await this._vizMSE.getProfile(this._profile)
-		const engines = await this._vizMSE.getEngines()
-		const result: Engine[] = []
-		const outputs = new Map<string, string>() // engine name : channel name
-		_.each(profile.execution_groups, (group, groupName) => {
-			_.each(group, (entry) => {
-				if (typeof entry === 'object' && entry.viz) {
-					if (typeof entry.viz === 'object' && entry.viz.value) {
-						outputs.set(entry.viz.value as string, groupName)
-					}
-				}
-			})
-		})
-		const outputEngines = engines.filter((engine) => {
-			return outputs.has(engine.name)
-		})
-		outputEngines.forEach((engine) => {
-			_.each(_.keys(engine.renderer), (fullHost) => {
-				const channelName = outputs.get(engine.name)
-				const match = fullHost.match(/([^:]+):?(\d*)?/)
-				const port = match && match[2] ? parseInt(match[2], 10) : 6100
-				const host = match && match[1] ? match[1] : fullHost
-				result.push({ name: engine.name, channel: channelName, host, port })
-			})
-		})
-		return result
-	}
-	private _filterEnginesToClear(engines: Engine[], channels: string[] | 'all'): Array<{ host: string; port: number }> {
-		return engines.filter((engine) => channels === 'all' || (engine.channel && channels.includes(engine.channel)))
-	}
-
-	public async setConcept(cmd: VizMSECommandSetConcept): Promise<void> {
-		const rundown: VRundown = await this._getRundown()
-		await rundown.setAlternativeConcept(cmd.concept)
-	}
-
-	/**
-	 * Load all elements: Trigger a loading of all pilot elements onto the vizEngine.
-	 * This might cause the vizEngine to freeze during load, so do not to it while on air!
-	 */
-	public async loadAllElements(_cmd: VizMSECommandLoadAllElements): Promise<void> {
-		this._triggerCommandSent()
-		await this._triggerLoadAllElements()
-		this._triggerCommandSent()
-	}
-
-	private async _initializeShows(showIds: string[]) {
-		const rundown = await this._getRundown()
-		this.emit('debug', `Triggering show ${showIds} init `)
-		for (const showId of showIds) {
-			try {
-				await rundown.initializeShow(showId)
-			} catch (e) {
-				this.emit('error', `Error in _initializeShows : ${e instanceof Error ? e.toString() : e}`)
-			}
-		}
-	}
-
-	public async initializeShows(cmd: VizMSECommandInitializeShows): Promise<void> {
-		const rundown = await this._getRundown()
-		this._initializedShows = new Set(cmd.showIds)
-		const expectedPlayoutItems = await this._prepareAndGetExpectedPlayoutItems()
-		if (this.purgeUnknownElements) {
-			this.emit('debug', `Purging shows ${cmd.showIds} `)
-			const elementsToKeep = Object.values(expectedPlayoutItems).filter(isVizMSEPlayoutItemContentInternalInstance)
-			await rundown.purgeInternalElements(cmd.showIds, true, elementsToKeep)
-		}
-		this._triggerCommandSent()
-		await this._initializeShows(cmd.showIds)
-		this._triggerCommandSent()
-	}
-
-	public async cleanupShows(cmd: VizMSECommandCleanupShows): Promise<void> {
-		this._triggerCommandSent()
-		await this._cleanupShows(cmd.showIds)
-		this._triggerCommandSent()
-	}
-
-	private async _cleanupShows(showIds: string[]) {
-		const rundown = await this._getRundown()
-		this.emit('debug', `Triggering show ${showIds} cleanup `)
-		await rundown.purgeInternalElements(showIds, true)
-		for (const showId of showIds) {
-			try {
-				await rundown.cleanupShow(showId)
-			} catch (e) {
-				this.emit('error', `Error in _cleanupShows : ${e instanceof Error ? e.toString() : e}`)
-			}
-		}
-	}
-
-	public async cleanupAllSofieShows(): Promise<void> {
-		this._triggerCommandSent()
-		const rundown = await this._getRundown()
-		try {
-			await rundown.cleanupAllSofieShows()
-		} catch (error) {
-			this.emit('error', `Error in cleanupAllSofieShows : ${error instanceof Error ? error.toString() : error}`)
-		}
-		this._triggerCommandSent()
-	}
-
-	/** Convenience function to get the data for an element */
-	static getTemplateData(layer: VizMSEStateLayer): string[] {
-		if (layer.contentType === TimelineContentTypeVizMSE.ELEMENT_INTERNAL) return layer.templateData
-		return []
-	}
-	/** Convenience function to get the "instance-id" of an element. This is intended to be unique for each usage/instance of the elemenet */
-	static getInternalElementInstanceName(layer: VizMSEStateLayerInternal | VIZMSEPlayoutItemContentInternal): string {
-		return `sofieInt_${layer.templateName}_${getHash((layer.templateData ?? []).join(','))}`
-	}
-
-	static getPlayoutItemContent(playoutItem: VIZMSEPlayoutItemContent): VizMSEPlayoutItemContentInstance {
-		if (isVIZMSEPlayoutItemContentExternal(playoutItem)) {
-			return playoutItem
-		} else {
-			return { ...playoutItem, instanceName: VizMSEManager.getInternalElementInstanceName(playoutItem) }
-		}
-	}
-	static getPlayoutItemContentFromLayer(layer: VizMSEStateLayer): VizMSEPlayoutItemContentInstance {
-		if (layer.contentType === TimelineContentTypeVizMSE.ELEMENT_INTERNAL) {
-			return {
-				templateName: layer.templateName,
-				templateData: this.getTemplateData(layer).map((data) => _.escape(data)),
-				instanceName: this.getInternalElementInstanceName(layer),
-				showId: layer.showId,
-			}
-		}
-		if (layer.contentType === TimelineContentTypeVizMSE.ELEMENT_PILOT) {
-			return literal<VizMSEPlayoutItemContentExternalInstance>({
-				vcpid: layer.templateVcpId,
-				channel: layer.channelName,
-			})
-		}
-		throw new Error(`Unknown layer.contentType "${layer['contentType']}"`)
-	}
-
-	private static _getElementHash(content: VizMSEPlayoutItemContentInstance): string {
-		if (isVizMSEPlayoutItemContentInternalInstance(content)) {
-			return `${content.showId}_${content.instanceName}`
-		} else {
-			return `pilot_${content.vcpid}_${content.channel}`
-		}
-	}
-
-	private _getCachedElement(content: VizMSEPlayoutItemContentInstance): CachedVElement | undefined
-	private _getCachedElement(hash: string): CachedVElement | undefined
-	private _getCachedElement(hashOrContent: string | VizMSEPlayoutItemContentInstance): CachedVElement | undefined {
-		if (typeof hashOrContent !== 'string') {
-			hashOrContent = VizMSEManager._getElementHash(hashOrContent)
-			return this._elementCache[hashOrContent]
-		} else {
-			return this._elementCache[hashOrContent]
-		}
-	}
-	private _cacheElement(content: VizMSEPlayoutItemContentInstance, element: VElement) {
-		const hash = VizMSEManager._getElementHash(content)
-		if (!element) throw new Error('_cacheElement: element not set (with hash ' + hash + ')')
-		if (this._elementCache[hash]) {
-			this.emit('warning', `There is already an element with hash "${hash}" in cache`)
-		}
-		this._elementCache[hash] = {
-			hash,
-			element,
-			content,
-			isLoaded: this._isElementLoaded(element),
-			isLoading: this._isElementLoading(element),
-		}
-	}
-	private _clearCache() {
-		_.each(_.keys(this._elementCache), (hash) => {
-			delete this._elementCache[hash]
-		})
-	}
-	private _getElementReference(el: InternalElement): string
-	private _getElementReference(el: ExternalElement): number
-	private _getElementReference(el: VElement): string | number
-	private _getElementReference(el: VElement): string | number {
-		if (this._isInternalElement(el)) return el.name
-		if (this._isExternalElement(el)) return Number(el.vcpid) // TMP!!
-
-		throw Error('Unknown element type, neither internal nor external')
-	}
-	private _isInternalElement(element: VElement): element is InternalElement {
-		const el = element as any
-		return el && el.name && !el.vcpid
-	}
-	private _isExternalElement(element: VElement): element is ExternalElement {
-		const el = element as any
-		return el && el.vcpid
-	}
-	/**
-	 * Check if element is already created, otherwise create it and return it.
-	 */
-	private async _checkPrepareElement(content: VizMSEPlayoutItemContentInstance, fromPrepare?: boolean) {
-		const cachedElement = this._getCachedElement(content)
-		let vElement = cachedElement ? cachedElement.element : undefined
-		if (cachedElement) {
-			cachedElement.toDelete = false
-		}
-		if (!vElement) {
-			const elementHash = VizMSEManager._getElementHash(content)
-			if (!fromPrepare) {
-				this.emit('warning', `Late preparation of element "${elementHash}"`)
-			} else {
-				this.emit('debug', `VizMSE: preparing new "${elementHash}"`)
-			}
-			vElement = await this._prepareNewElement(content)
-
-			if (!fromPrepare) await this._wait(100) // wait a bit, because taking isn't possible right away anyway at this point
-		}
-	}
-	/** Check that the element exists and if not, throw error */
-	private async _checkElementExists(cmd: VizMSECommandElementBase): Promise<void> {
-		const rundown = await this._getRundown()
-
-		const cachedElement = this._getCachedElement(cmd.content)
-		if (!cachedElement) throw new Error(`_checkElementExists: cachedElement falsy`)
-		const elementRef = this._getElementReference(cachedElement.element)
-		const elementIsExternal = cachedElement && this._isExternalElement(cachedElement.element)
-
-		if (elementIsExternal) {
-			const element = await rundown.getElement(cmd.content)
-			if (this._isExternalElement(element) && element.exists === 'no') {
-				throw new Error(`Can't take the element "${elementRef}" while it has the property exists="no"`)
-			}
-		}
-	}
-	/**
-	 * Create a new element in MSE
-	 */
-	private async _prepareNewElement(content: VizMSEPlayoutItemContentInstance): Promise<VElement> {
-		const rundown = await this._getRundown()
-
-		try {
-			if (isVizMSEPlayoutItemContentExternalInstance(content)) {
-				// Prepare a pilot element
-				const pilotEl = await rundown.createElement(content)
-
-				this._cacheElement(content, pilotEl)
-				return pilotEl
-			} else {
-				// Prepare an internal element
-				const internalEl = await rundown.createElement(
-					content,
-					content.templateName,
-					content.templateData || [],
-					content.channel
-				)
-
-				this._cacheElement(content, internalEl)
-				return internalEl
-			}
-		} catch (e) {
-			if ((e as Error).toString().match(/already exist/i)) {
-				// "An internal/external graphics element with name 'xxxxxxxxxxxxxxx' already exists."
-				// If the object already exists, it's not an error, fetch and use the element instead
-
-				const element = await rundown.getElement(content)
-
-				this._cacheElement(content, element)
-				return element
-			} else {
-				throw e
-			}
-		}
-	}
-	private async _deleteElement(content: VizMSEPlayoutItemContentInstance) {
-		const rundown = await this._getRundown()
-		this._triggerCommandSent()
-		await rundown.deleteElement(content)
-		this._triggerCommandSent()
-	}
-	private async _prepareAndGetExpectedPlayoutItems(): Promise<{ [hash: string]: VizMSEPlayoutItemContentInstance }> {
-		this.emit('debug', `VISMSE: _prepareAndGetExpectedPlayoutItems (${this._expectedPlayoutItems.length})`)
-
-		const hashesAndItems: { [hash: string]: VizMSEPlayoutItemContentInstance } = {}
-
-		const expectedPlayoutItems = _.uniq(
-			_.filter(this._expectedPlayoutItems, (expectedPlayoutItem) => {
-				return (
-					(!this._preloadedRundownPlaylistId ||
-						!expectedPlayoutItem.playlistId ||
-						this._preloadedRundownPlaylistId === expectedPlayoutItem.playlistId) &&
-					(isVIZMSEPlayoutItemContentInternal(expectedPlayoutItem) ||
-						isVIZMSEPlayoutItemContentExternal(expectedPlayoutItem))
-				)
-			}),
-			false,
-			(a) => JSON.stringify(_.pick(a, 'templateName', 'templateData', 'vcpid', 'showId'))
-		)
-
-		await Promise.all(
-			_.map(expectedPlayoutItems, async (expectedPlayoutItem) => {
-				const content = VizMSEManager.getPlayoutItemContent(expectedPlayoutItem)
-				const hash = VizMSEManager._getElementHash(content)
-				try {
-					await this._checkPrepareElement(content, true)
-					hashesAndItems[hash] = content
-				} catch (e) {
-					this.emit('error', `Error in _prepareAndGetExpectedPlayoutItems for "${hash}": ${(e as Error).toString()}`)
-				}
-			})
-		)
-		return hashesAndItems
-	}
-
-	/**
-	 * Update the load-statuses of the expectedPlayoutItems -elements from MSE, where needed
-	 */
-	private async updateElementsLoadedStatus(forceReloadAll?: boolean) {
-		const hashesAndItems = await this._prepareAndGetExpectedPlayoutItems()
-		let someUnloaded = false
-		const elementsToLoad = _.compact(
-			_.map(hashesAndItems, (item, hash) => {
-				const el = this._getCachedElement(hash)
-				if (!item.noAutoPreloading && el) {
-					if (el.wasLoaded && !el.isLoaded && !el.isLoading) {
-						someUnloaded = true
-					}
-					return el
-				}
-				return undefined
-			})
-		)
-		if (this._rundown) {
-			this.emit(
-				'debug',
-				`Updating status of elements starting, activePlaylistId="${
-					this._preloadedRundownPlaylistId
-				}", elementsToLoad.length=${elementsToLoad.length} (${_.keys(hashesAndItems).length})`
-			)
-
-			const rundown = await this._getRundown()
-
-			if (forceReloadAll) {
-				elementsToLoad.forEach((element) => {
-					element.isLoaded = false
-					element.isLoading = false
-					element.requestedLoading = false
-					element.wasLoaded = false
-				})
-			}
-			if (someUnloaded) {
-				await this._triggerRundownActivate(rundown)
-			}
-
-			await Promise.all(
-				_.map(elementsToLoad, async (cachedEl) => {
-					try {
-						await this._checkPrepareElement(cachedEl.content)
-
-						this.emit('debug', `Updating status of element ${cachedEl.hash}`)
-
-						// Update cached status of the element:
-						const newEl = await rundown.getElement(cachedEl.content)
-
-						const newLoadedEl = {
-							...cachedEl,
-							isExpected: true,
-							isLoaded: this._isElementLoaded(newEl),
-							isLoading: this._isElementLoading(newEl),
-						}
-						this._elementCache[cachedEl.hash] = newLoadedEl
-						this.emit('debug', `Element ${cachedEl.hash}: ${JSON.stringify(newEl)}`)
-						if (isVizMSEPlayoutItemContentExternalInstance(cachedEl.content)) {
-							if (this._updateAfterReconnect || cachedEl?.isLoaded !== newLoadedEl.isLoaded) {
-								if (cachedEl?.isLoaded && !newLoadedEl.isLoaded) {
-									newLoadedEl.wasLoaded = true
-								} else if (!cachedEl?.isLoaded && newLoadedEl.isLoaded) {
-									newLoadedEl.wasLoaded = false
-								}
-								const vcpid = cachedEl.content.vcpid
-								if (newLoadedEl.isLoaded) {
-									const mediaObject: MediaObject = {
-										_id: cachedEl.hash,
-										mediaId: 'PILOT_' + vcpid,
-										mediaPath: vcpid.toString(),
-										mediaSize: 0,
-										mediaTime: 0,
-										thumbSize: 0,
-										thumbTime: 0,
-										cinf: '',
-										tinf: '',
-										_rev: '',
-									}
-									this.emit('updateMediaObject', cachedEl.hash, mediaObject)
-								} else {
-									this.emit('updateMediaObject', cachedEl.hash, null)
-								}
-							}
-							if (newLoadedEl.wasLoaded && !newLoadedEl.isLoaded && !newLoadedEl.isLoading) {
-								this.emit(
-									'debug',
-									`Element "${this._getElementReference(newEl)}" went from loaded to not loaded, initializing`
-								)
-								await rundown.initialize(cachedEl.content)
-							}
-						}
-					} catch (e) {
-						this.emit('error', `Error in updateElementsLoadedStatus: ${(e as Error).toString()}`)
-					}
-				})
-			)
-			this._updateAfterReconnect = false
-			this.emit('debug', `Updating status of elements done`)
-		} else {
-			throw Error('VizMSE.v-connection not initialized yet')
-		}
-	}
-	private async _triggerRundownActivate(rundown: VRundown): Promise<void> {
-		try {
-			this.emit('debug', 'rundown.activate triggered')
-			await rundown.activate()
-		} catch (error) {
-			this.emit('warning', `Ignored error for rundown.activate(): ${error}`)
-		}
-		this._triggerCommandSent()
-		await this._wait(1000)
-		this._triggerCommandSent()
-	}
-	/**
-	 * Trigger a load of all elements that are not yet loaded onto the vizEngine.
-	 */
-	private async _triggerLoadAllElements(loadTwice = false): Promise<void> {
-		if (this._loadingAllElements) {
-			this.emit('warning', '_triggerLoadAllElements already running')
-			return
-		}
-		this._loadingAllElements = true
-		try {
-			const rundown = await this._getRundown()
-
-			this.emit('debug', '_triggerLoadAllElements starting')
-			// First, update the loading-status of all elements:
-			await this.updateElementsLoadedStatus(true)
-
-			// if (this._initializeRundownOnLoadAll) {
-
-			// Then, load all elements that needs loading:
-			const loadAllElementsThatNeedsLoading = async () => {
-				const showIdsToInitialize = new Set<string>()
-				this._triggerCommandSent()
-				await this._triggerRundownActivate(rundown)
-				await Promise.all(
-					_.map(this._elementCache, async (e) => {
-						if (isVizMSEPlayoutItemContentInternalInstance(e.content)) {
-							showIdsToInitialize.add(e.content.showId)
-							e.requestedLoading = true
-						} else if (isVizMSEPlayoutItemContentExternalInstance(e.content)) {
-							if (e.isLoaded) {
-								// The element is loaded fine, no need to do anything
-								this.emit('debug', `Element "${VizMSEManager._getElementHash(e.content)}" is loaded`)
-							} else if (e.isLoading) {
-								// The element is currently loading, do nothing
-								this.emit('debug', `Element "${VizMSEManager._getElementHash(e.content)}" is loading`)
-							} else if (e.isExpected) {
-								// The element has not started loading, load it:
-								this.emit('debug', `Element "${VizMSEManager._getElementHash(e.content)}" is not loaded, initializing`)
-								await rundown.initialize(e.content)
-							}
-						} else {
-							this.emit('error', `Element "${VizMSEManager._getElementHash(e.content)}" type `)
-						}
-					})
-				)
-				await this._initializeShows(Array.from(showIdsToInitialize))
-			}
-
-			// He's making a list:
-			await loadAllElementsThatNeedsLoading()
-			await this._wait(2000)
-			if (loadTwice) {
-				// He's checking it twice:
-				await this.updateElementsLoadedStatus()
-				// Gonna find out what's loaded and nice:
-				await loadAllElementsThatNeedsLoading()
-			}
-
-			this.emit('debug', '_triggerLoadAllElements done')
-		} finally {
-			this._loadingAllElements = false
-		}
-	}
-	private _setMonitorLoadedElementsTimeout(): void {
-		if (this._monitorAndLoadElementsTimeout) {
-			clearTimeout(this._monitorAndLoadElementsTimeout)
-		}
-		if (!this._terminated) {
-			this._monitorAndLoadElementsTimeout = setTimeout(() => {
-				this._monitorLoadedElements()
-					.catch((...args) => {
-						this.emit('error', ...args)
-					})
-					.finally(() => {
-						this._setMonitorLoadedElementsTimeout()
-					})
-			}, MONITOR_INTERVAL)
-		}
-	}
-	private _setMonitorConnectionTimeout(): void {
-		if (this._monitorMSEConnectionTimeout) {
-			clearTimeout(this._monitorMSEConnectionTimeout)
-		}
-		if (!this._terminated) {
-			this._monitorMSEConnectionTimeout = setTimeout(() => {
-				this._monitorConnection()
-					.catch((...args) => {
-						this.emit('error', ...args)
-					})
-					.finally(() => {
-						this._setMonitorConnectionTimeout()
-					})
-			}, MONITOR_INTERVAL)
-		}
-	}
-	private async _monitorConnection(): Promise<void> {
-		if (this.initialized) {
-			// (the ping will throw on a timeout if ping doesn't return in time)
-			return this._vizMSE
-				.ping()
-				.then(() => {
-					// ok!
-					if (!this._msePingConnected) {
-						this._msePingConnected = true
-						this.onConnectionChanged()
-					}
-				})
-				.catch(() => {
-					// not ok!
-					if (this._msePingConnected) {
-						this._msePingConnected = false
-						this.onConnectionChanged()
-					}
-				})
-				.then(async () => {
-					return this._msePingConnected ? this._monitorEngines() : Promise.resolve()
-				})
-		}
-		return Promise.reject()
-	}
-	private async _monitorEngines() {
-		if (!this.engineRestPort) {
-			return
-		}
-		const engines = await this._getEngines()
-		const ps: Promise<EngineStatus>[] = []
-		engines.forEach((engine) => {
-			return ps.push(this._pingEngine(engine))
-		})
-		const statuses = await Promise.all(ps)
-		const enginesDisconnected: string[] = []
-		statuses.forEach((status) => {
-			if (!status.alive) {
-				enginesDisconnected.push(`${status.channel || status.name} (${status.host})`)
-			}
-		})
-		if (!_.isEqual(enginesDisconnected, this.enginesDisconnected)) {
-			this.enginesDisconnected = enginesDisconnected
-			this.onConnectionChanged()
-		}
-	}
-	private async _pingEngine(engine: Engine): Promise<EngineStatus> {
-		return new Promise((resolve) => {
-			const url = `http://${engine.host}:${this.engineRestPort}/#/status`
-			request.get(url, { timeout: 2000 }, (error, response: request.Response | undefined) => {
-				const alive = !error && response !== undefined && response?.statusCode < 400
-				if (!alive) {
-					this.emit('debug', `VizMSE: _pingEngine at "${url}", error ${error}, code ${response?.statusCode}`)
-				}
-				resolve({ ...engine, alive })
-			})
-		})
-	}
-	/** Monitor loading status of expected elements */
-	private async _monitorLoadedElements(): Promise<void> {
-		try {
-			if (
-				this._rundown &&
-				this._hasActiveRundown &&
-				this.preloadAllElements &&
-				this._timeSinceLastCommandSent() > SAFE_PRELOAD_TIME
-			) {
-				await this.updateElementsLoadedStatus(false)
-
-				let notLoaded = 0
-				let loading = 0
-				let loaded = 0
-
-				_.each(this._elementCache, (e) => {
-					if (e.isLoaded) loaded++
-					else if (e.isLoading) loading++
-					else notLoaded++
-				})
-
-				if (notLoaded > 0 || loading > 0) {
-					// emit debug data
-					this.emit('debug', `Items on queue: notLoaded: ${notLoaded} loading: ${loading}, loaded: ${loaded}`)
-
-					this.emit(
-						'debug',
-						`_elementsLoaded: ${_.map(_.filter(this._elementCache, (e) => !e.isLoaded).slice(0, 10), (e) => {
-							return JSON.stringify(e.element)
-						})}`
-					)
-				}
-
-				this._setLoadedStatus(notLoaded, loading)
-			} else this._setLoadedStatus(0, 0)
-		} catch (e) {
-			this.emit('error', e)
-		}
-	}
-	private async _wait(time: number): Promise<void> {
-		if (this.ignoreAllWaits) return Promise.resolve()
-		return new Promise((resolve) => setTimeout(resolve, time))
-	}
-	/** Execute fcn an retry a couple of times until it succeeds */
-	private async _handleRetry<T>(fcn: () => Promise<T>): Promise<T> {
-		let i = 0
-		const maxNumberOfTries = 5
-
-		// eslint-disable-next-line no-constant-condition
-		while (true) {
-			try {
-				this._triggerCommandSent()
-				const result = fcn()
-				this._triggerCommandSent()
-				return result
-			} catch (e: any) {
-				if (i++ < maxNumberOfTries) {
-					if (e?.toString && e?.toString().match(/inexistent/i)) {
-						// "PepTalk inexistent error"
-						this.emit('debug', `VizMSE: _handleRetry got "inexistent" error, trying again...`)
-
-						// Wait and try again:
-						await this._wait(300)
-					} else {
-						// Unhandled error, give up:
-						throw e
-					}
-				} else {
-					// Give up, we've tried enough times already
-					throw e
-				}
-			}
-		}
-	}
-	private _triggerCommandSent(): void {
-		this._lastTimeCommandSent = Date.now()
-	}
-	private _timeSinceLastCommandSent(): number {
-		return Date.now() - this._lastTimeCommandSent
-	}
-	private _setLoadedStatus(notLoaded: number, loading: number) {
-		if (notLoaded !== this.notLoadedCount || loading !== this.loadingCount) {
-			this.notLoadedCount = notLoaded
-			this.loadingCount = loading
-			this._parentVizMSEDevice.connectionChanged()
-		}
-	}
-	/**
-	 * Returns true if the element is successfully loaded (as opposed to "not-loaded" or "loading")
-	 */
-	private _isElementLoaded(el: VElement): boolean {
-		if (this._isInternalElement(el)) {
-			return (
-				(el.available === '1.00' || el.available === '1' || el.available === undefined) &&
-				(el.loaded === '1.00' || el.loaded === '1') &&
-				el.is_loading !== 'yes'
-			)
-		} else if (this._isExternalElement(el)) {
-			return (
-				(el.available === '1.00' || el.available === '1') &&
-				(el.loaded === '1.00' || el.loaded === '1') &&
-				el.is_loading !== 'yes'
-			)
-		} else {
-			throw new Error(`vizMSE: _isLoaded: unknown element type: ${el && JSON.stringify(el)}`)
-		}
-	}
-	/**
-	 * Returns true if the element has NOT started loading (is currently not loading, or finished loaded)
-	 */
-	private _isElementLoading(el: VElement) {
-		if (this._isInternalElement(el)) {
-			return el.loaded !== '1.00' && el.loaded !== '1' && el.is_loading === 'yes'
-		} else if (this._isExternalElement(el)) {
-			return el.loaded !== '1.00' && el.loaded !== '1' && el.is_loading === 'yes'
-		} else {
-			throw new Error(`vizMSE: _isLoaded: unknown element type: ${el && JSON.stringify(el)}`)
-		}
-	}
-	/**
-	 * Return the current MSE rundown, create it if it doesn't exists
-	 */
-	private async _getRundown(): Promise<VRundown> {
-		if (!this._rundown) {
-			// Only allow for one rundown fetch at the same time:
-			if (this._getRundownPromise) {
-				return this._getRundownPromise
-			}
-
-			const getRundownPromise = (async () => {
-				// Check if the rundown already exists:
-				// let rundown: VRundown | undefined = _.find(await this._vizMSE.getRundowns(), (rundown) => {
-				// 	return (
-				// 		rundown.show === this._showID &&
-				// 		rundown.profile === this._profile &&
-				// 		rundown.playlist === this._playlistID
-				// 	)
-				// })
-
-				this.emit('debug', `Creating new rundown ${[this._profile, this._playlistID]}`)
-
-				const rundown = await this._vizMSE.createRundown(this._profile, this._playlistID)
-
-				this._rundown = rundown
-				if (!this._rundown) throw new Error(`_getRundown: this._rundown is not set!`)
-				return this._rundown
-			})()
-
-			this._getRundownPromise = getRundownPromise
-
-			try {
-				const rundown = await this._getRundownPromise
-				this._rundown = rundown
-				return rundown
-			} catch (e) {
-				this._getRundownPromise = undefined
-				throw e
-			}
-		} else {
-			return this._rundown
-		}
-	}
-	private mseConnectionChanged(connected: boolean) {
-		if (connected !== this._mseConnected) {
-			if (connected) {
-				// not the first connection
-				if (this._mseConnected === false) {
-					this._updateAfterReconnect = true
-				}
-			}
-			this._mseConnected = connected
-			this.onConnectionChanged()
-		}
-	}
-	private onConnectionChanged() {
-		this.emit('connectionChanged', this._mseConnected && this._msePingConnected)
-	}
-
-	public clearAllWaitWithLayer(portId: string) {
-		if (!this._waitWithLayers[portId]) {
-			_.each(this._waitWithLayers[portId], (fcn) => {
-				fcn(true)
-			})
-		}
-	}
-	/**
-	 * Returns true if the wait was cleared from someone else
-	 */
-	private async waitWithLayer(layerId: string, delay: number): Promise<boolean> {
-		return new Promise((resolve) => {
-			if (!this._waitWithLayers[layerId]) this._waitWithLayers[layerId] = []
-			this._waitWithLayers[layerId].push(resolve)
-			setTimeout(() => {
-				resolve(false)
-			}, delay || 0)
-		})
-	}
-}
-
-interface VizMSEState {
-	time: number
-	layer: {
-		[layerId: string]: VizMSEStateLayer
-	}
-	/** Special: If this is set, all other state will be disregarded and all graphics will be cleared */
-	isClearAll?: {
-		timelineObjId: string
-		showId: string
-		channelsToSendCommands?: string[]
-	}
-}
-type VizMSEStateLayer =
-	| VizMSEStateLayerInternal
-	| VizMSEStateLayerPilot
-	| VizMSEStateLayerContinue
-	| VizMSEStateLayerLoadAllElements
-	| VizMSEStateLayerInitializeShows
-	| VizMSEStateLayerCleanupShows
-	| VizMSEStateLayerConcept
-
-interface VizMSEStateLayerBase {
-	timelineObjId: string
-	lookahead?: boolean
-	/** Whether this element should have its take delayed until after an out transition has finished */
-	delayTakeAfterOutTransition?: boolean
-}
-interface VizMSEStateLayerElementBase extends VizMSEStateLayerBase {
-	contentType: TimelineContentTypeVizMSE
-	continueStep?: number
-	cue?: boolean
-
-	outTransition?: VIZMSEOutTransition
-}
-interface VizMSEStateLayerInternal extends VizMSEStateLayerElementBase {
-	contentType: TimelineContentTypeVizMSE.ELEMENT_INTERNAL
-
-	templateName: string
-	templateData: Array<string>
-	showId: string
-	channelName?: string
-}
-interface VizMSEStateLayerPilot extends VizMSEStateLayerElementBase {
-	contentType: TimelineContentTypeVizMSE.ELEMENT_PILOT
-
-	templateVcpId: number
-	channelName?: string
-}
-interface VizMSEStateLayerContinue extends VizMSEStateLayerBase {
-	contentType: TimelineContentTypeVizMSE.CONTINUE
-
-	direction?: 1 | -1
-
-	reference: string
-	referenceContent?: VizMSEStateLayerInternal | VizMSEStateLayerPilot
-}
-interface VizMSEStateLayerInitializeShows extends VizMSEStateLayerBase {
-	contentType: TimelineContentTypeVizMSE.INITIALIZE_SHOWS
-
-	showIds: string[]
-}
-interface VizMSEStateLayerCleanupShows extends VizMSEStateLayerBase {
-	contentType: TimelineContentTypeVizMSE.CLEANUP_SHOWS
-	/** IDs of the Shows to cleanup - 'all' will cleanup all shows */
-	showIds: string[]
-}
-interface VizMSEStateLayerLoadAllElements extends VizMSEStateLayerBase {
-	contentType: TimelineContentTypeVizMSE.LOAD_ALL_ELEMENTS
-}
-interface VizMSEStateLayerConcept extends VizMSEStateLayerBase {
-	contentType: TimelineContentTypeVizMSE.CONCEPT
-	concept: string
-}
-
-interface VizMSECommandBase {
-	time: number
-	type: VizMSECommandType
-	timelineObjId: string
-	fromLookahead?: boolean
-	layerId?: string
-}
-export enum VizMSECommandType {
-	PREPARE_ELEMENT = 'prepare',
-	CUE_ELEMENT = 'cue',
-	TAKE_ELEMENT = 'take',
-	TAKEOUT_ELEMENT = 'out',
-	CONTINUE_ELEMENT = 'continue',
-	CONTINUE_ELEMENT_REVERSE = 'continuereverse',
-	LOAD_ALL_ELEMENTS = 'load_all_elements',
-	CLEAR_ALL_ELEMENTS = 'clear_all_elements',
-	CLEAR_ALL_ENGINES = 'clear_all_engines',
-	INITIALIZE_SHOWS = 'initialize_shows',
-	CLEANUP_SHOWS = 'cleanup_shows',
-	SET_CONCEPT = 'set_concept',
-}
-
-interface VizMSECommandElementBase extends VizMSECommandBase {
-	content: VizMSEPlayoutItemContentInstance
-}
-interface VizMSECommandPrepare extends VizMSECommandElementBase {
-	type: VizMSECommandType.PREPARE_ELEMENT
-}
-interface VizMSECommandCue extends VizMSECommandElementBase {
-	type: VizMSECommandType.CUE_ELEMENT
-}
-interface VizMSECommandTake extends VizMSECommandElementBase {
-	type: VizMSECommandType.TAKE_ELEMENT
-	transition?: VIZMSEOutTransition
-}
-interface VizMSECommandTakeOut extends VizMSECommandElementBase {
-	type: VizMSECommandType.TAKEOUT_ELEMENT
-	transition?: VIZMSEOutTransition
-}
-interface VizMSECommandContinue extends VizMSECommandElementBase {
-	type: VizMSECommandType.CONTINUE_ELEMENT
-}
-interface VizMSECommandContinueReverse extends VizMSECommandElementBase {
-	type: VizMSECommandType.CONTINUE_ELEMENT_REVERSE
-}
-interface VizMSECommandLoadAllElements extends VizMSECommandBase {
-	type: VizMSECommandType.LOAD_ALL_ELEMENTS
-}
-interface VizMSECommandClearAllElements extends VizMSECommandBase {
-	type: VizMSECommandType.CLEAR_ALL_ELEMENTS
-
-	templateName: string
-	showId: string
-}
-interface VizMSECommandClearAllEngines extends VizMSECommandBase {
-	type: VizMSECommandType.CLEAR_ALL_ENGINES
-
-	channels: string[] | 'all'
-	commands: string[]
-}
-interface VizMSECommandInitializeShows extends VizMSECommandBase {
-	type: VizMSECommandType.INITIALIZE_SHOWS
-	showIds: string[]
-}
-interface VizMSECommandCleanupShows extends VizMSECommandBase {
-	type: VizMSECommandType.CLEANUP_SHOWS
-	showIds: string[]
-}
-
-interface VizMSECommandSetConcept extends VizMSECommandBase {
-	type: VizMSECommandType.SET_CONCEPT
-	concept: string
-}
-
-type VizMSECommand =
-	| VizMSECommandPrepare
-	| VizMSECommandCue
-	| VizMSECommandTake
-	| VizMSECommandTakeOut
-	| VizMSECommandContinue
-	| VizMSECommandContinueReverse
-	| VizMSECommandLoadAllElements
-	| VizMSECommandClearAllElements
-	| VizMSECommandClearAllEngines
-	| VizMSECommandInitializeShows
-	| VizMSECommandCleanupShows
-	| VizMSECommandSetConcept
-
-interface VizMSEPlayoutItemContentInternalInstance extends VIZMSEPlayoutItemContentInternal {
-	/** Name of the instance of the element in MSE, generated by us */
-	instanceName: string
-}
-type VizMSEPlayoutItemContentExternalInstance = VIZMSEPlayoutItemContentExternal
-
-type VizMSEPlayoutItemContentInstance =
-	| VizMSEPlayoutItemContentInternalInstance
-	| VizMSEPlayoutItemContentExternalInstance
-
-function isVizMSEPlayoutItemContentExternalInstance(
-	content: VizMSEPlayoutItemContentInstance
-): content is VizMSEPlayoutItemContentExternalInstance {
-	return (content as VizMSEPlayoutItemContentExternalInstance).vcpid !== undefined
-}
-
-function isVizMSEPlayoutItemContentInternalInstance(
-	content: VizMSEPlayoutItemContentInstance
-): content is VizMSEPlayoutItemContentInternalInstance {
-	return (content as VizMSEPlayoutItemContentInternalInstance).templateName !== undefined
-}
-
-function isVIZMSEPlayoutItemContentExternal(
-	content: VIZMSEPlayoutItemContent
-): content is VIZMSEPlayoutItemContentExternal {
-	return (content as VIZMSEPlayoutItemContentExternal).vcpid !== undefined
-}
-
-function isVIZMSEPlayoutItemContentInternal(
-	content: VIZMSEPlayoutItemContent
-): content is VIZMSEPlayoutItemContentInternal {
-	return (content as VIZMSEPlayoutItemContentInternal).templateName !== undefined
-}
-
-interface CachedVElement {
-	readonly hash: string
-	readonly element: VElement
-	readonly content: VizMSEPlayoutItemContentInstance
-
-	isExpected?: boolean
-	isLoaded?: boolean
-	isLoading?: boolean
-	wasLoaded?: boolean
-	requestedLoading?: boolean
-	toDelete?: boolean
-}
-
-function content2StateLayer(
-	timelineObjId: string,
-	content: TimelineObjVIZMSEElementInternal['content'] | TimelineObjVIZMSEElementPilot['content']
-): VizMSEStateLayer | undefined {
-	if (content.type === TimelineContentTypeVizMSE.ELEMENT_INTERNAL) {
-		const o: VizMSEStateLayerInternal = {
-			timelineObjId: timelineObjId,
-			contentType: TimelineContentTypeVizMSE.ELEMENT_INTERNAL,
-			continueStep: content.continueStep,
-			cue: content.cue,
-			outTransition: content.outTransition,
-
-			templateName: content.templateName,
-			templateData: content.templateData,
-			channelName: content.channelName,
-			delayTakeAfterOutTransition: content.delayTakeAfterOutTransition,
-			showId: content.showId,
-		}
-		return o
-	} else if (content.type === TimelineContentTypeVizMSE.ELEMENT_PILOT) {
-		const o: VizMSEStateLayerPilot = {
-			timelineObjId: timelineObjId,
-			contentType: TimelineContentTypeVizMSE.ELEMENT_PILOT,
-			continueStep: content.continueStep,
-			cue: content.cue,
-			outTransition: content.outTransition,
-
-			templateVcpId: content.templateVcpId,
-			channelName: content.channelName,
-			delayTakeAfterOutTransition: content.delayTakeAfterOutTransition,
-		}
-		return o
-	}
-	return undefined
-}
-
-class VizEngineTcpSender extends EventEmitter {
-	private _socket: net.Socket = new net.Socket()
-	private _port: number
-	private _host: string
-	private _connected = false
-	private _commandCount = 0
-	private _sendQueue: string[] = []
-	private _waitQueue: Set<number> = new Set()
-	private _incomingData = ''
-	private _responseTimeoutMs = 6000
-
-	constructor(port: number, host: string) {
-		super()
-		this._port = port
-		this._host = host
-	}
-
-	send(commands: string[]) {
-		commands.forEach((command) => {
-			this._sendQueue.push(command)
-		})
-		if (this._connected) {
-			this._flushQueue()
-		} else {
-			this._connect()
-		}
-	}
-
-	private _connect() {
-		this._socket = net.createConnection(this._port, this._host)
-		this._socket.on('connect', () => {
-			this._connected = true
-			if (this._sendQueue.length) {
-				this._flushQueue()
-			}
-		})
-		this._socket.on('error', (e) => {
-			this.emit('error', e)
-			this._destroy()
-		})
-		this._socket.on('lookup', () => {
-			// this handles a dns exception, but the error is handled on 'error' event
-		})
-		this._socket.on('data', this._processData.bind(this))
-	}
-
-	private _flushQueue() {
-		this._sendQueue.forEach((command) => {
-			this._socket.write(`${++this._commandCount} ${command}\x00`)
-			this._waitQueue.add(this._commandCount)
-		})
-		setTimeout(() => {
-			if (this._waitQueue.size) {
-				this.emit('warning', `Response from ${this._host}:${this._port} not received on time`)
-				this._destroy()
-			}
-		}, this._responseTimeoutMs)
-	}
-
-	private _processData(data: Buffer) {
-		this._incomingData = this._incomingData.concat(data.toString())
-		const split = this._incomingData.split('\x00')
-		if (split.length === 0 || (split.length === 1 && split[0] === '')) return
-		if (split[split.length - 1] !== '') {
-			this._incomingData = split.pop()!
-		} else {
-			this._incomingData = ''
-		}
-		split.forEach((message) => {
-			const firstSpace = message.indexOf(' ')
-			const id = message.substr(0, firstSpace)
-			const contents = message.substr(firstSpace + 1)
-			if (contents.startsWith('ERROR')) {
-				this.emit('warning', contents)
-			}
-			this._waitQueue.delete(parseInt(id, 10))
-		})
-		if (this._waitQueue.size === 0) {
-			this._destroy()
-		}
-	}
-
-	private _destroy() {
-		this._socket.destroy()
-		this.removeAllListeners()
 	}
 }

--- a/packages/timeline-state-resolver/src/integrations/vizMSE/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/index.ts
@@ -298,18 +298,18 @@ export class VizMSEDevice extends DeviceWithState<VizMSEState, DeviceOptionsVizM
 							state.layer[layerName] = literal<VizMSEStateLayerInitializeShows>({
 								timelineObjId: l.id,
 								contentType: TimelineContentTypeVizMSE.INITIALIZE_SHOWS,
-								showIds: this._vizmseManager
-									? _.compact(l.content.showNames.map(this._vizmseManager.resolveShowNameToId.bind(this)))
-									: [],
+								showIds: _.compact(
+									l.content.showNames.map((showName) => this._vizmseManager?.resolveShowNameToId(showName))
+								),
 							})
 							break
 						case TimelineContentTypeVizMSE.CLEANUP_SHOWS:
 							state.layer[layerName] = literal<VizMSEStateLayerCleanupShows>({
 								timelineObjId: l.id,
 								contentType: TimelineContentTypeVizMSE.CLEANUP_SHOWS,
-								showIds: this._vizmseManager
-									? _.compact(l.content.showNames.map(this._vizmseManager.resolveShowNameToId.bind(this)))
-									: [],
+								showIds: _.compact(
+									l.content.showNames.map((showName) => this._vizmseManager?.resolveShowNameToId(showName))
+								),
 							})
 							break
 						case TimelineContentTypeVizMSE.CONCEPT:

--- a/packages/timeline-state-resolver/src/integrations/vizMSE/types.ts
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/types.ts
@@ -1,0 +1,215 @@
+import {
+	TimelineContentTypeVizMSE,
+	VIZMSEOutTransition,
+	VIZMSEPlayoutItemContent,
+	VIZMSEPlayoutItemContentExternal,
+	VIZMSEPlayoutItemContentInternal,
+} from 'timeline-state-resolver-types'
+import { VElement } from '@tv2media/v-connection'
+
+export interface VizMSEState {
+	time: number
+	layer: {
+		[layerId: string]: VizMSEStateLayer
+	}
+	/** Special: If this is set, all other state will be disregarded and all graphics will be cleared */
+	isClearAll?: {
+		timelineObjId: string
+		showId: string
+		channelsToSendCommands?: string[]
+	}
+}
+export type VizMSEStateLayer =
+	| VizMSEStateLayerInternal
+	| VizMSEStateLayerPilot
+	| VizMSEStateLayerContinue
+	| VizMSEStateLayerLoadAllElements
+	| VizMSEStateLayerInitializeShows
+	| VizMSEStateLayerCleanupShows
+	| VizMSEStateLayerConcept
+interface VizMSEStateLayerBase {
+	timelineObjId: string
+	lookahead?: boolean
+	/** Whether this element should have its take delayed until after an out transition has finished */
+	delayTakeAfterOutTransition?: boolean
+}
+interface VizMSEStateLayerElementBase extends VizMSEStateLayerBase {
+	contentType: TimelineContentTypeVizMSE
+	continueStep?: number
+	cue?: boolean
+
+	outTransition?: VIZMSEOutTransition
+}
+export interface VizMSEStateLayerInternal extends VizMSEStateLayerElementBase {
+	contentType: TimelineContentTypeVizMSE.ELEMENT_INTERNAL
+
+	templateName: string
+	templateData: Array<string>
+	showId: string
+	channelName?: string
+}
+export interface VizMSEStateLayerPilot extends VizMSEStateLayerElementBase {
+	contentType: TimelineContentTypeVizMSE.ELEMENT_PILOT
+
+	templateVcpId: number
+	channelName?: string
+}
+export interface VizMSEStateLayerContinue extends VizMSEStateLayerBase {
+	contentType: TimelineContentTypeVizMSE.CONTINUE
+
+	direction?: 1 | -1
+
+	reference: string
+	referenceContent?: VizMSEStateLayerInternal | VizMSEStateLayerPilot
+}
+export interface VizMSEStateLayerInitializeShows extends VizMSEStateLayerBase {
+	contentType: TimelineContentTypeVizMSE.INITIALIZE_SHOWS
+
+	showIds: string[]
+}
+export interface VizMSEStateLayerCleanupShows extends VizMSEStateLayerBase {
+	contentType: TimelineContentTypeVizMSE.CLEANUP_SHOWS
+	/** IDs of the Shows to cleanup */
+	showIds: string[]
+}
+export interface VizMSEStateLayerLoadAllElements extends VizMSEStateLayerBase {
+	contentType: TimelineContentTypeVizMSE.LOAD_ALL_ELEMENTS
+}
+export interface VizMSEStateLayerConcept extends VizMSEStateLayerBase {
+	contentType: TimelineContentTypeVizMSE.CONCEPT
+	concept: string
+}
+interface VizMSECommandBase {
+	time: number
+	type: VizMSECommandType
+	timelineObjId: string
+	fromLookahead?: boolean
+	layerId?: string
+}
+export enum VizMSECommandType {
+	PREPARE_ELEMENT = 'prepare',
+	CUE_ELEMENT = 'cue',
+	TAKE_ELEMENT = 'take',
+	TAKEOUT_ELEMENT = 'out',
+	CONTINUE_ELEMENT = 'continue',
+	CONTINUE_ELEMENT_REVERSE = 'continuereverse',
+	LOAD_ALL_ELEMENTS = 'load_all_elements',
+	CLEAR_ALL_ELEMENTS = 'clear_all_elements',
+	CLEAR_ALL_ENGINES = 'clear_all_engines',
+	INITIALIZE_SHOWS = 'initialize_shows',
+	CLEANUP_SHOWS = 'cleanup_shows',
+	SET_CONCEPT = 'set_concept',
+}
+
+export interface VizMSECommandElementBase extends VizMSECommandBase {
+	content: VizMSEPlayoutItemContentInstance
+}
+export interface VizMSECommandPrepare extends VizMSECommandElementBase {
+	type: VizMSECommandType.PREPARE_ELEMENT
+}
+export interface VizMSECommandCue extends VizMSECommandElementBase {
+	type: VizMSECommandType.CUE_ELEMENT
+}
+export interface VizMSECommandTake extends VizMSECommandElementBase {
+	type: VizMSECommandType.TAKE_ELEMENT
+	transition?: VIZMSEOutTransition
+}
+export interface VizMSECommandTakeOut extends VizMSECommandElementBase {
+	type: VizMSECommandType.TAKEOUT_ELEMENT
+	transition?: VIZMSEOutTransition
+}
+export interface VizMSECommandContinue extends VizMSECommandElementBase {
+	type: VizMSECommandType.CONTINUE_ELEMENT
+}
+export interface VizMSECommandContinueReverse extends VizMSECommandElementBase {
+	type: VizMSECommandType.CONTINUE_ELEMENT_REVERSE
+}
+export interface VizMSECommandLoadAllElements extends VizMSECommandBase {
+	type: VizMSECommandType.LOAD_ALL_ELEMENTS
+}
+export interface VizMSECommandClearAllElements extends VizMSECommandBase {
+	type: VizMSECommandType.CLEAR_ALL_ELEMENTS
+
+	templateName: string
+	showId: string
+}
+export interface VizMSECommandClearAllEngines extends VizMSECommandBase {
+	type: VizMSECommandType.CLEAR_ALL_ENGINES
+
+	channels: string[] | 'all'
+	commands: string[]
+}
+export interface VizMSECommandInitializeShows extends VizMSECommandBase {
+	type: VizMSECommandType.INITIALIZE_SHOWS
+	showIds: string[]
+}
+export interface VizMSECommandCleanupShows extends VizMSECommandBase {
+	type: VizMSECommandType.CLEANUP_SHOWS
+	showIds: string[]
+}
+
+export interface VizMSECommandSetConcept extends VizMSECommandBase {
+	type: VizMSECommandType.SET_CONCEPT
+	concept: string
+}
+export type VizMSECommand =
+	| VizMSECommandPrepare
+	| VizMSECommandCue
+	| VizMSECommandTake
+	| VizMSECommandTakeOut
+	| VizMSECommandContinue
+	| VizMSECommandContinueReverse
+	| VizMSECommandLoadAllElements
+	| VizMSECommandClearAllElements
+	| VizMSECommandClearAllEngines
+	| VizMSECommandInitializeShows
+	| VizMSECommandCleanupShows
+	| VizMSECommandSetConcept
+interface VizMSEPlayoutItemContentInternalInstance extends Omit<VIZMSEPlayoutItemContentInternal, 'showName'> {
+	/** Name of the instance of the element in MSE, generated by us */
+	instanceName: string
+	/** Resolved Id of the Show to place this element in */
+	showId: string
+}
+export type VizMSEPlayoutItemContentExternalInstance = VIZMSEPlayoutItemContentExternal
+
+export type VizMSEPlayoutItemContentInstance =
+	| VizMSEPlayoutItemContentInternalInstance
+	| VizMSEPlayoutItemContentExternalInstance
+
+export function isVizMSEPlayoutItemContentExternalInstance(
+	content: VizMSEPlayoutItemContentInstance
+): content is VizMSEPlayoutItemContentExternalInstance {
+	return (content as VizMSEPlayoutItemContentExternalInstance).vcpid !== undefined
+}
+
+export function isVizMSEPlayoutItemContentInternalInstance(
+	content: VizMSEPlayoutItemContentInstance
+): content is VizMSEPlayoutItemContentInternalInstance {
+	return (content as VizMSEPlayoutItemContentInternalInstance).templateName !== undefined
+}
+
+export function isVIZMSEPlayoutItemContentExternal(
+	content: VIZMSEPlayoutItemContent
+): content is VIZMSEPlayoutItemContentExternal {
+	return (content as VIZMSEPlayoutItemContentExternal).vcpid !== undefined
+}
+
+export function isVIZMSEPlayoutItemContentInternal(
+	content: VIZMSEPlayoutItemContent
+): content is VIZMSEPlayoutItemContentInternal {
+	return (content as VIZMSEPlayoutItemContentInternal).templateName !== undefined
+}
+
+export interface CachedVElement {
+	readonly hash: string
+	readonly element: VElement
+	readonly content: VizMSEPlayoutItemContentInstance
+
+	isExpected?: boolean
+	isLoaded?: boolean
+	isLoading?: boolean
+	wasLoaded?: boolean
+	requestedLoading?: boolean
+	toDelete?: boolean
+}

--- a/packages/timeline-state-resolver/src/integrations/vizMSE/vizEngineTcpSender.ts
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/vizEngineTcpSender.ts
@@ -1,0 +1,90 @@
+import { EventEmitter } from 'events'
+import * as net from 'net'
+
+export class VizEngineTcpSender extends EventEmitter {
+	private _socket: net.Socket = new net.Socket()
+	private _port: number
+	private _host: string
+	private _connected = false
+	private _commandCount = 0
+	private _sendQueue: string[] = []
+	private _waitQueue: Set<number> = new Set()
+	private _incomingData = ''
+	private _responseTimeoutMs = 6000
+
+	constructor(port: number, host: string) {
+		super()
+		this._port = port
+		this._host = host
+	}
+
+	send(commands: string[]) {
+		commands.forEach((command) => {
+			this._sendQueue.push(command)
+		})
+		if (this._connected) {
+			this._flushQueue()
+		} else {
+			this._connect()
+		}
+	}
+
+	private _connect() {
+		this._socket = net.createConnection(this._port, this._host)
+		this._socket.on('connect', () => {
+			this._connected = true
+			if (this._sendQueue.length) {
+				this._flushQueue()
+			}
+		})
+		this._socket.on('error', (e) => {
+			this.emit('error', e)
+			this._destroy()
+		})
+		this._socket.on('lookup', () => {
+			// this handles a dns exception, but the error is handled on 'error' event
+		})
+		this._socket.on('data', this._processData.bind(this))
+	}
+
+	private _flushQueue() {
+		this._sendQueue.forEach((command) => {
+			this._socket.write(`${++this._commandCount} ${command}\x00`)
+			this._waitQueue.add(this._commandCount)
+		})
+		setTimeout(() => {
+			if (this._waitQueue.size) {
+				this.emit('warning', `Response from ${this._host}:${this._port} not received on time`)
+				this._destroy()
+			}
+		}, this._responseTimeoutMs)
+	}
+
+	private _processData(data: Buffer) {
+		this._incomingData = this._incomingData.concat(data.toString())
+		const split = this._incomingData.split('\x00')
+		if (split.length === 0 || (split.length === 1 && split[0] === '')) return
+		if (split[split.length - 1] !== '') {
+			this._incomingData = split.pop()!
+		} else {
+			this._incomingData = ''
+		}
+		split.forEach((message) => {
+			const firstSpace = message.indexOf(' ')
+			const id = message.substr(0, firstSpace)
+			const contents = message.substr(firstSpace + 1)
+			if (contents.startsWith('ERROR')) {
+				this.emit('warning', contents)
+			}
+			this._waitQueue.delete(parseInt(id, 10))
+		})
+		if (this._waitQueue.size === 0) {
+			this._destroy()
+		}
+	}
+
+	private _destroy() {
+		this._socket.destroy()
+		this.removeAllListeners()
+	}
+}

--- a/packages/timeline-state-resolver/src/integrations/vizMSE/vizMSEManager.ts
+++ b/packages/timeline-state-resolver/src/integrations/vizMSE/vizMSEManager.ts
@@ -1,0 +1,1246 @@
+import * as _ from 'underscore'
+import { EventEmitter } from 'events'
+import { literal } from '../../devices/device'
+import {
+	MediaObject,
+	TimelineContentTypeVizMSE,
+	VIZMSEPlayoutItemContent,
+	VIZMSEPlayoutItemContentInternal,
+	VIZMSETransitionType,
+} from 'timeline-state-resolver-types'
+import { ExternalElement, InternalElement, MSE, VElement, VRundown } from '@tv2media/v-connection'
+import { ExpectedPlayoutItem } from '../../expectedPlayoutItems'
+import * as request from 'request'
+import { deferAsync } from '../../lib'
+import { VizMSEDevice } from './index'
+import {
+	CachedVElement,
+	isVizMSEPlayoutItemContentInternalInstance,
+	isVizMSEPlayoutItemContentExternalInstance,
+	VizMSECommandPrepare,
+	VizMSECommandCue,
+	VizMSECommandElementBase,
+	VizMSECommandTake,
+	VizMSECommandTakeOut,
+	VizMSECommandContinue,
+	VizMSECommandContinueReverse,
+	VizMSECommandClearAllElements,
+	VizMSEStateLayerInternal,
+	VizMSECommandType,
+	VizMSECommandClearAllEngines,
+	VizMSECommandSetConcept,
+	VizMSECommandLoadAllElements,
+	VizMSECommandInitializeShows,
+	VizMSECommandCleanupShows,
+	VizMSEStateLayer,
+	VizMSEPlayoutItemContentInstance,
+	isVIZMSEPlayoutItemContentExternal,
+	VizMSEPlayoutItemContentExternalInstance,
+	isVIZMSEPlayoutItemContentInternal,
+} from './types'
+import { VizEngineTcpSender } from './vizEngineTcpSender'
+import * as crypto from 'crypto'
+import * as path from 'path'
+
+/** Minimum time to wait before removing an element after an expectedPlayoutItem has been removed */
+const DELETE_TIME_WAIT = 20 * 1000
+
+// How often to check / preload elements
+const MONITOR_INTERVAL = 5 * 1000
+
+// How long to wait after any action (takes, cues, etc) before trying to cue for preloading
+const SAFE_PRELOAD_TIME = 2000
+
+// How long to wait before retrying to ping the MSE when initializing the rundown, after a failed attempt
+const INIT_RETRY_INTERVAL = 3000
+
+// Appears at the end of show names in the directory
+const SHOW_EXTENSION = '.show'
+
+export function getHash(str: string): string {
+	const hash = crypto.createHash('sha1')
+	return hash.update(str).digest('base64').replace(/[+/=]/g, '_') // remove +/= from strings, because they cause troubles
+}
+
+export type Engine = { name: string; channel?: string; host: string; port: number }
+export type EngineStatus = Engine & { alive: boolean }
+
+export class VizMSEManager extends EventEmitter {
+	public initialized = false
+	public notLoadedCount = 0
+	public loadingCount = 0
+	public enginesDisconnected: Array<string> = []
+
+	private _rundown: VRundown | undefined
+	private _elementCache: { [hash: string]: CachedVElement } = {}
+	private _expectedPlayoutItems: Array<ExpectedPlayoutItem> = []
+	private _monitorAndLoadElementsTimeout?: NodeJS.Timer
+	private _monitorMSEConnectionTimeout?: NodeJS.Timer
+	private _lastTimeCommandSent = 0
+	private _hasActiveRundown = false
+	private _getRundownPromise?: Promise<VRundown>
+	private _mseConnected: boolean | undefined = undefined // undefined: first connection not established yet
+	private _msePingConnected = false
+	private _loadingAllElements = false
+	private _waitWithLayers: {
+		[portId: string]: Function[]
+	} = {}
+	public ignoreAllWaits = false // Only to be used in tests
+	private _terminated = false
+	private _activeRundownPlaylistId: string | undefined
+	private _preloadedRundownPlaylistId: string | undefined
+	private _updateAfterReconnect = false
+	private _initializedShows = new Set<string>()
+	private _showToIdMap: Map<string, string> | undefined
+
+	public get activeRundownPlaylistId() {
+		return this._activeRundownPlaylistId
+	}
+
+	constructor(
+		private _parentVizMSEDevice: VizMSEDevice,
+		private _vizMSE: MSE,
+		public preloadAllElements: boolean,
+		public onlyPreloadActivePlaylist: boolean,
+		public purgeUnknownElements: boolean,
+		public autoLoadInternalElements: boolean,
+		public engineRestPort: number | undefined,
+		private _showDirectoryPath: string,
+		private _profile: string,
+		private _playlistID?: string
+	) {
+		super()
+	}
+	/**
+	 * Initialize the Rundown in MSE.
+	 * Our approach is to create a single rundown on initialization, and then use only that for later control.
+	 */
+	public async initializeRundown(activeRundownPlaylistId: string | undefined): Promise<void> {
+		this._vizMSE.on('connected', () => this.mseConnectionChanged(true))
+		this._vizMSE.on('disconnected', () => this.mseConnectionChanged(false))
+		this._vizMSE.on('warning', (message: string) => this.emit('warning', 'v-connection: ' + message))
+		this._activeRundownPlaylistId = activeRundownPlaylistId
+		this._preloadedRundownPlaylistId = this.onlyPreloadActivePlaylist ? activeRundownPlaylistId : undefined
+
+		if (activeRundownPlaylistId) {
+			this.emit('debug', `VizMSE: already active playlist: ${this._preloadedRundownPlaylistId}`)
+		}
+
+		const initializeRundownInner = async () => {
+			try {
+				// Perform a ping, to ensure we are connected properly
+				await this._vizMSE.ping()
+				this._msePingConnected = true
+				this.mseConnectionChanged(true)
+
+				// Setup the rundown used by this device:
+				const rundown = await this._getRundown()
+
+				if (!rundown) throw new Error(`VizMSEManager: Unable to create rundown!`)
+
+				this._showToIdMap = await this._vizMSE.listShowsFromDirectory()
+			} catch (e) {
+				this.emit('debug', `VizMSE: initializeRundownInner ${e}`)
+				setTimeout(() => {
+					deferAsync(
+						async () => initializeRundownInner(),
+						(_e) => {
+							// ignore error
+						}
+					)
+				}, INIT_RETRY_INTERVAL)
+				return
+			}
+
+			// const profile = await this._vizMSE.getProfile('sofie') // TODO: Figure out if this is needed
+			this._setMonitorLoadedElementsTimeout()
+			this._setMonitorConnectionTimeout()
+
+			this.initialized = true
+		}
+
+		await initializeRundownInner()
+	}
+	/**
+	 * Close connections and die
+	 */
+	public async terminate() {
+		this._terminated = true
+		if (this._monitorAndLoadElementsTimeout) {
+			clearTimeout(this._monitorAndLoadElementsTimeout)
+		}
+		if (this._monitorMSEConnectionTimeout) {
+			clearTimeout(this._monitorMSEConnectionTimeout)
+		}
+		if (this._vizMSE) {
+			await this._vizMSE.close()
+		}
+	}
+	/**
+	 * Set the collection of expectedPlayoutItems.
+	 * These will be monitored and can be triggered to pre-load.
+	 */
+	public setExpectedPlayoutItems(expectedPlayoutItems: Array<ExpectedPlayoutItem>) {
+		this.emit('debug', 'VIZDEBUG: setExpectedPlayoutItems called')
+		if (this.preloadAllElements) {
+			this.emit('debug', 'VIZDEBUG: preload elements allowed')
+			this._expectedPlayoutItems = expectedPlayoutItems
+			this._prepareAndGetExpectedPlayoutItems() // Calling this in order to trigger creation of all elements
+				.then(async (hashesAndItems) => {
+					if (this._rundown && this._hasActiveRundown) {
+						this.emit('debug', 'VIZDEBUG: auto load internal elements...')
+						await this.updateElementsLoadedStatus()
+
+						const elementHashesToDelete: string[] = []
+						// When a new element is added, we'll trigger a show init:
+						const showIdsToInitialize = new Set<string>()
+						_.each(this._elementCache, (element) => {
+							if (isVizMSEPlayoutItemContentInternalInstance(element.content)) {
+								if (!element.isLoaded && !element.requestedLoading) {
+									this.emit('debug', `Element "${this._getElementReference(element.element)}" is not loaded`)
+									if (this.autoLoadInternalElements || this._initializedShows.has(element.content.showId)) {
+										showIdsToInitialize.add(element.content.showId)
+										element.requestedLoading = true
+									}
+								}
+							}
+							if (!hashesAndItems[element.hash] && !element.toDelete) {
+								elementHashesToDelete.push(element.hash)
+								this._elementCache[element.hash].toDelete = true
+							}
+						})
+						const uniqueShowIds = Array.from(showIdsToInitialize)
+						await this._initializeShows(uniqueShowIds)
+
+						setTimeout(() => {
+							Promise.all(
+								elementHashesToDelete.map(async (elementHash) => {
+									const element = this._elementCache[elementHash]
+									if (element?.toDelete) {
+										await this._deleteElement(element.content)
+										delete this._elementCache[elementHash]
+									}
+								})
+							).catch((error) => this.emit('error', error))
+						}, DELETE_TIME_WAIT)
+					}
+				})
+				.catch((error) => this.emit('error', error))
+		}
+	}
+	/**
+	 * Activate the rundown.
+	 * This causes the MSE rundown to activate, which must be done before using it.
+	 * Doing this will make MSE start loading things onto the vizEngine etc.
+	 */
+	public async activate(rundownPlaylistId: string | undefined): Promise<void> {
+		this._preloadedRundownPlaylistId = this.onlyPreloadActivePlaylist ? rundownPlaylistId : undefined
+		let loadTwice = false
+		if (!rundownPlaylistId || this._activeRundownPlaylistId !== rundownPlaylistId) {
+			this._triggerCommandSent()
+			const rundown = await this._getRundown()
+
+			// clear any existing elements from the existing rundown
+			try {
+				this.emit('debug', `VizMSE: purging rundown`)
+				const elementsToKeep = this._expectedPlayoutItems
+					.filter((item) => !!item.baseline)
+					.map((playoutItem) => this.getPlayoutItemContent(playoutItem))
+					.filter(isVizMSEPlayoutItemContentExternalInstance)
+
+				await rundown.purgeExternalElements(elementsToKeep)
+			} catch (error) {
+				this.emit('error', error)
+			}
+			this._clearCache()
+			this._clearMediaObjects()
+			loadTwice = true
+		}
+
+		this._triggerCommandSent()
+		this._triggerLoadAllElements(loadTwice)
+			.then(async () => {
+				this._triggerCommandSent()
+				this._activeRundownPlaylistId = rundownPlaylistId
+				this._hasActiveRundown = true
+
+				if (this.purgeUnknownElements) {
+					const rundown = await this._getRundown()
+					const elementsInRundown = await rundown.listExternalElements()
+					const hashesAndItems = await this._prepareAndGetExpectedPlayoutItems()
+
+					for (const element of elementsInRundown) {
+						// Check if that element is in our expectedPlayoutItems list
+						if (!hashesAndItems[VizMSEManager._getElementHash(element)]) {
+							// The element in the Viz-rundown seems to be unknown to us
+							await rundown.deleteElement(element)
+						}
+					}
+				}
+			})
+			.catch((e) => {
+				this.emit('error', e)
+			})
+	}
+	/**
+	 * Deactivate the MSE rundown.
+	 * This causes the MSE to stand down and clear the vizEngines of any loaded graphics.
+	 */
+	public async deactivate(): Promise<void> {
+		const rundown = await this._getRundown()
+		this._triggerCommandSent()
+		await rundown.deactivate()
+		this._triggerCommandSent()
+		this.standDownActiveRundown()
+		this._clearMediaObjects()
+	}
+	public standDownActiveRundown(): void {
+		this._hasActiveRundown = false
+		this._activeRundownPlaylistId = undefined
+	}
+	private _clearMediaObjects(): void {
+		this.emit('clearMediaObjects')
+	}
+	/**
+	 * Prepare an element
+	 * This creates the element and is intended to be called a little time ahead of Takeing the element.
+	 */
+	public async prepareElement(cmd: VizMSECommandPrepare): Promise<void> {
+		this.logCommand(cmd, 'prepare')
+		this._triggerCommandSent()
+		await this._checkPrepareElement(cmd.content, true)
+		this._triggerCommandSent()
+	}
+	/**
+	 * Cue:ing an element: Load and play the first frame of a graphic
+	 */
+	public async cueElement(cmd: VizMSECommandCue): Promise<void> {
+		const rundown = await this._getRundown()
+
+		await this._checkPrepareElement(cmd.content)
+
+		await this._checkElementExists(cmd)
+		await this._handleRetry(async () => {
+			this.logCommand(cmd, 'cue')
+			return rundown.cue(cmd.content)
+		})
+	}
+
+	logCommand(cmd: VizMSECommandElementBase, commandName: string) {
+		const content = cmd.content
+		if (isVizMSEPlayoutItemContentInternalInstance(content)) {
+			this.emit('debug', `VizMSE: ${commandName} "${content.instanceName}" in show "${content.showId}"`)
+		} else {
+			this.emit('debug', `VizMSE: ${commandName} "${content.vcpid}" on channel "${content.channel}"`)
+		}
+	}
+
+	/**
+	 * Take an element: Load and Play a graphic element, run in-animatinos etc
+	 */
+	public async takeElement(cmd: VizMSECommandTake): Promise<void> {
+		const rundown = await this._getRundown()
+
+		await this._checkPrepareElement(cmd.content)
+
+		if (cmd.transition) {
+			if (cmd.transition.type === VIZMSETransitionType.DELAY) {
+				if (await this.waitWithLayer(cmd.layerId || '__default', cmd.transition.delay)) {
+					// at this point, the wait aws aborted by someone else. Do nothing then.
+					return
+				}
+			}
+		}
+
+		await this._checkElementExists(cmd)
+		await this._handleRetry(async () => {
+			this.logCommand(cmd, 'take')
+			return rundown.take(cmd.content)
+		})
+	}
+	/**
+	 * Take out: Animate out a graphic element
+	 */
+	public async takeoutElement(cmd: VizMSECommandTakeOut): Promise<void> {
+		const rundown = await this._getRundown()
+
+		if (cmd.transition) {
+			if (cmd.transition.type === VIZMSETransitionType.DELAY) {
+				if (await this.waitWithLayer(cmd.layerId || '__default', cmd.transition.delay)) {
+					// at this point, the wait aws aborted by someone else. Do nothing then.
+					return
+				}
+			}
+		}
+
+		await this._checkPrepareElement(cmd.content)
+
+		await this._checkElementExists(cmd)
+		await this._handleRetry(async () => {
+			this.logCommand(cmd, 'out')
+			return rundown.out(cmd.content)
+		})
+	}
+	/**
+	 * Continue: Cause the graphic element to step forward, if it has multiple states
+	 */
+	public async continueElement(cmd: VizMSECommandContinue): Promise<void> {
+		const rundown = await this._getRundown()
+
+		await this._checkPrepareElement(cmd.content)
+
+		await this._checkElementExists(cmd)
+		await this._handleRetry(async () => {
+			this.logCommand(cmd, 'continue')
+			return rundown.continue(cmd.content)
+		})
+	}
+	/**
+	 * Continue-reverse: Cause the graphic element to step backwards, if it has multiple states
+	 */
+	public async continueElementReverse(cmd: VizMSECommandContinueReverse): Promise<void> {
+		const rundown = await this._getRundown()
+
+		await this._checkPrepareElement(cmd.content)
+
+		await this._checkElementExists(cmd)
+		await this._handleRetry(async () => {
+			this.logCommand(cmd, 'continue reverse')
+			return rundown.continueReverse(cmd.content)
+		})
+	}
+	/**
+	 * Special: trigger a template which clears all templates on the output
+	 */
+	public async clearAll(cmd: VizMSECommandClearAllElements): Promise<void> {
+		const rundown = await this._getRundown()
+
+		const template: VizMSEStateLayerInternal = {
+			timelineObjId: cmd.timelineObjId,
+			contentType: TimelineContentTypeVizMSE.ELEMENT_INTERNAL,
+			templateName: cmd.templateName,
+			templateData: [],
+			showId: cmd.showId,
+		}
+		// Start playing special element:
+		const cmdTake: VizMSECommandTake = {
+			time: cmd.time,
+			type: VizMSECommandType.TAKE_ELEMENT,
+			timelineObjId: template.timelineObjId,
+			content: VizMSEManager.getPlayoutItemContentFromLayer(template),
+		}
+
+		await this._checkPrepareElement(cmdTake.content)
+
+		await this._checkElementExists(cmdTake)
+		await this._handleRetry(async () => {
+			this.logCommand(cmdTake, 'clearAll take')
+			return rundown.take(cmdTake.content)
+		})
+	}
+	/**
+	 * Special: send commands to Viz Engines in order to clear them
+	 */
+	public async clearEngines(cmd: VizMSECommandClearAllEngines): Promise<void> {
+		try {
+			const engines = await this._getEngines()
+			const enginesToClear = this._filterEnginesToClear(engines, cmd.channels)
+			enginesToClear.forEach((engine) => {
+				const sender = new VizEngineTcpSender(engine.port, engine.host)
+				sender.on('warning', (w) => this.emit('warning', `clearEngines: ${w}`))
+				sender.on('error', (e) => this.emit('error', `clearEngines: ${e}`))
+				sender.send(cmd.commands)
+			})
+		} catch (e) {
+			this.emit('warning', `Sending Clear-all command failed ${e}`)
+		}
+	}
+	private async _getEngines(): Promise<Engine[]> {
+		const profile = await this._vizMSE.getProfile(this._profile)
+		const engines = await this._vizMSE.getEngines()
+		const result: Engine[] = []
+		const outputs = new Map<string, string>() // engine name : channel name
+		_.each(profile.execution_groups, (group, groupName) => {
+			_.each(group, (entry) => {
+				if (typeof entry === 'object' && entry.viz) {
+					if (typeof entry.viz === 'object' && entry.viz.value) {
+						outputs.set(entry.viz.value as string, groupName)
+					}
+				}
+			})
+		})
+		const outputEngines = engines.filter((engine) => {
+			return outputs.has(engine.name)
+		})
+		outputEngines.forEach((engine) => {
+			_.each(_.keys(engine.renderer), (fullHost) => {
+				const channelName = outputs.get(engine.name)
+				const match = fullHost.match(/([^:]+):?(\d*)?/)
+				const port = match && match[2] ? parseInt(match[2], 10) : 6100
+				const host = match && match[1] ? match[1] : fullHost
+				result.push({ name: engine.name, channel: channelName, host, port })
+			})
+		})
+		return result
+	}
+	private _filterEnginesToClear(engines: Engine[], channels: string[] | 'all'): Array<{ host: string; port: number }> {
+		return engines.filter((engine) => channels === 'all' || (engine.channel && channels.includes(engine.channel)))
+	}
+
+	public async setConcept(cmd: VizMSECommandSetConcept): Promise<void> {
+		const rundown: VRundown = await this._getRundown()
+		await rundown.setAlternativeConcept(cmd.concept)
+	}
+
+	/**
+	 * Load all elements: Trigger a loading of all pilot elements onto the vizEngine.
+	 * This might cause the vizEngine to freeze during load, so do not to it while on air!
+	 */
+	public async loadAllElements(_cmd: VizMSECommandLoadAllElements): Promise<void> {
+		this._triggerCommandSent()
+		await this._triggerLoadAllElements()
+		this._triggerCommandSent()
+	}
+
+	private async _initializeShows(showIds: string[]) {
+		const rundown = await this._getRundown()
+		this.emit('debug', `Triggering show ${showIds} init `)
+		for (const showId of showIds) {
+			try {
+				await rundown.initializeShow(showId)
+			} catch (e) {
+				this.emit('error', `Error in _initializeShows : ${e instanceof Error ? e.toString() : e}`)
+			}
+		}
+	}
+
+	public async initializeShows(cmd: VizMSECommandInitializeShows): Promise<void> {
+		const rundown = await this._getRundown()
+		this._initializedShows = new Set(cmd.showIds)
+		const expectedPlayoutItems = await this._prepareAndGetExpectedPlayoutItems()
+		if (this.purgeUnknownElements) {
+			this.emit('debug', `Purging shows ${cmd.showIds} `)
+			const elementsToKeep = Object.values(expectedPlayoutItems).filter(isVizMSEPlayoutItemContentInternalInstance)
+			await rundown.purgeInternalElements(cmd.showIds, true, elementsToKeep)
+		}
+		this._triggerCommandSent()
+		await this._initializeShows(cmd.showIds)
+		this._triggerCommandSent()
+	}
+
+	public async cleanupShows(cmd: VizMSECommandCleanupShows): Promise<void> {
+		this._triggerCommandSent()
+		await this._cleanupShows(cmd.showIds)
+		this._triggerCommandSent()
+	}
+
+	private async _cleanupShows(showIds: string[]) {
+		const rundown = await this._getRundown()
+		this.emit('debug', `Triggering show ${showIds} cleanup `)
+		await rundown.purgeInternalElements(showIds, true)
+		for (const showId of showIds) {
+			try {
+				await rundown.cleanupShow(showId)
+			} catch (e) {
+				this.emit('error', `Error in _cleanupShows : ${e instanceof Error ? e.toString() : e}`)
+			}
+		}
+	}
+
+	public async cleanupAllSofieShows(): Promise<void> {
+		this._triggerCommandSent()
+		const rundown = await this._getRundown()
+		try {
+			await rundown.cleanupAllSofieShows()
+		} catch (error) {
+			this.emit('error', `Error in cleanupAllSofieShows : ${error instanceof Error ? error.toString() : error}`)
+		}
+		this._triggerCommandSent()
+	}
+
+	public resolveShowNameToId(showName: string): string | undefined {
+		const showNameWithExtension = path.extname(showName) === SHOW_EXTENSION ? showName : `${showName}${SHOW_EXTENSION}`
+		return this._showToIdMap?.get(path.posix.join(this._showDirectoryPath, showNameWithExtension))
+	}
+
+	/** Convenience function to get the data for an element */
+	static getTemplateData(layer: VizMSEStateLayer): string[] {
+		if (layer.contentType === TimelineContentTypeVizMSE.ELEMENT_INTERNAL) return layer.templateData
+		return []
+	}
+	/** Convenience function to get the "instance-id" of an element. This is intended to be unique for each usage/instance of the elemenet */
+	static getInternalElementInstanceName(layer: VizMSEStateLayerInternal | VIZMSEPlayoutItemContentInternal): string {
+		return `sofieInt_${layer.templateName}_${getHash((layer.templateData ?? []).join(','))}`
+	}
+
+	getPlayoutItemContent(playoutItem: VIZMSEPlayoutItemContent): VizMSEPlayoutItemContentInstance | undefined {
+		if (isVIZMSEPlayoutItemContentExternal(playoutItem)) {
+			return playoutItem
+		}
+		const showId = this.resolveShowNameToId(playoutItem.showName)
+		if (!showId) {
+			this.emit(
+				'warning',
+				`getPlayoutItemContent: Unable to find Show Id for template "${playoutItem.templateName}" and Show Name "${playoutItem.showName}"`
+			)
+			return undefined
+		}
+		return {
+			...playoutItem,
+			instanceName: VizMSEManager.getInternalElementInstanceName(playoutItem),
+			showId,
+		}
+	}
+	static getPlayoutItemContentFromLayer(layer: VizMSEStateLayer): VizMSEPlayoutItemContentInstance {
+		if (layer.contentType === TimelineContentTypeVizMSE.ELEMENT_INTERNAL) {
+			return {
+				templateName: layer.templateName,
+				templateData: this.getTemplateData(layer).map((data) => _.escape(data)),
+				instanceName: this.getInternalElementInstanceName(layer),
+				showId: layer.showId,
+			}
+		}
+		if (layer.contentType === TimelineContentTypeVizMSE.ELEMENT_PILOT) {
+			return literal<VizMSEPlayoutItemContentExternalInstance>({
+				vcpid: layer.templateVcpId,
+				channel: layer.channelName,
+			})
+		}
+		throw new Error(`Unknown layer.contentType "${layer['contentType']}"`)
+	}
+
+	private static _getElementHash(content: VizMSEPlayoutItemContentInstance): string {
+		if (isVizMSEPlayoutItemContentInternalInstance(content)) {
+			return `${content.showId}_${content.instanceName}`
+		} else {
+			return `pilot_${content.vcpid}_${content.channel}`
+		}
+	}
+
+	private _getCachedElement(content: VizMSEPlayoutItemContentInstance): CachedVElement | undefined
+	private _getCachedElement(hash: string): CachedVElement | undefined
+	private _getCachedElement(hashOrContent: string | VizMSEPlayoutItemContentInstance): CachedVElement | undefined {
+		if (typeof hashOrContent !== 'string') {
+			hashOrContent = VizMSEManager._getElementHash(hashOrContent)
+			return this._elementCache[hashOrContent]
+		} else {
+			return this._elementCache[hashOrContent]
+		}
+	}
+	private _cacheElement(content: VizMSEPlayoutItemContentInstance, element: VElement) {
+		const hash = VizMSEManager._getElementHash(content)
+		if (!element) throw new Error('_cacheElement: element not set (with hash ' + hash + ')')
+		if (this._elementCache[hash]) {
+			this.emit('warning', `There is already an element with hash "${hash}" in cache`)
+		}
+		this._elementCache[hash] = {
+			hash,
+			element,
+			content,
+			isLoaded: this._isElementLoaded(element),
+			isLoading: this._isElementLoading(element),
+		}
+	}
+	private _clearCache() {
+		_.each(_.keys(this._elementCache), (hash) => {
+			delete this._elementCache[hash]
+		})
+	}
+	private _getElementReference(el: InternalElement): string
+	private _getElementReference(el: ExternalElement): number
+	private _getElementReference(el: VElement): string | number
+	private _getElementReference(el: VElement): string | number {
+		if (this._isInternalElement(el)) return el.name
+		if (this._isExternalElement(el)) return Number(el.vcpid) // TMP!!
+
+		throw Error('Unknown element type, neither internal nor external')
+	}
+	private _isInternalElement(element: VElement): element is InternalElement {
+		const el = element as any
+		return el && el.name && !el.vcpid
+	}
+	private _isExternalElement(element: VElement): element is ExternalElement {
+		const el = element as any
+		return el && el.vcpid
+	}
+	/**
+	 * Check if element is already created, otherwise create it and return it.
+	 */
+	private async _checkPrepareElement(content: VizMSEPlayoutItemContentInstance, fromPrepare?: boolean) {
+		const cachedElement = this._getCachedElement(content)
+		let vElement = cachedElement ? cachedElement.element : undefined
+		if (cachedElement) {
+			cachedElement.toDelete = false
+		}
+		if (!vElement) {
+			const elementHash = VizMSEManager._getElementHash(content)
+			if (!fromPrepare) {
+				this.emit('warning', `Late preparation of element "${elementHash}"`)
+			} else {
+				this.emit('debug', `VizMSE: preparing new "${elementHash}"`)
+			}
+			vElement = await this._prepareNewElement(content)
+
+			if (!fromPrepare) await this._wait(100) // wait a bit, because taking isn't possible right away anyway at this point
+		}
+	}
+	/** Check that the element exists and if not, throw error */
+	private async _checkElementExists(cmd: VizMSECommandElementBase): Promise<void> {
+		const rundown = await this._getRundown()
+
+		const cachedElement = this._getCachedElement(cmd.content)
+		if (!cachedElement) throw new Error(`_checkElementExists: cachedElement falsy`)
+		const elementRef = this._getElementReference(cachedElement.element)
+		const elementIsExternal = cachedElement && this._isExternalElement(cachedElement.element)
+
+		if (elementIsExternal) {
+			const element = await rundown.getElement(cmd.content)
+			if (this._isExternalElement(element) && element.exists === 'no') {
+				throw new Error(`Can't take the element "${elementRef}" while it has the property exists="no"`)
+			}
+		}
+	}
+	/**
+	 * Create a new element in MSE
+	 */
+	private async _prepareNewElement(content: VizMSEPlayoutItemContentInstance): Promise<VElement> {
+		const rundown = await this._getRundown()
+
+		try {
+			if (isVizMSEPlayoutItemContentExternalInstance(content)) {
+				// Prepare a pilot element
+				const pilotEl = await rundown.createElement(content)
+
+				this._cacheElement(content, pilotEl)
+				return pilotEl
+			} else {
+				// Prepare an internal element
+				const internalEl = await rundown.createElement(
+					content,
+					content.templateName,
+					content.templateData || [],
+					content.channel
+				)
+
+				this._cacheElement(content, internalEl)
+				return internalEl
+			}
+		} catch (e) {
+			if ((e as Error).toString().match(/already exist/i)) {
+				// "An internal/external graphics element with name 'xxxxxxxxxxxxxxx' already exists."
+				// If the object already exists, it's not an error, fetch and use the element instead
+				const element = await rundown.getElement(content)
+
+				this._cacheElement(content, element)
+				return element
+			} else {
+				throw e
+			}
+		}
+	}
+	private async _deleteElement(content: VizMSEPlayoutItemContentInstance) {
+		const rundown = await this._getRundown()
+		this._triggerCommandSent()
+		await rundown.deleteElement(content)
+		this._triggerCommandSent()
+	}
+	private async _prepareAndGetExpectedPlayoutItems(): Promise<{ [hash: string]: VizMSEPlayoutItemContentInstance }> {
+		this.emit('debug', `VISMSE: _prepareAndGetExpectedPlayoutItems (${this._expectedPlayoutItems.length})`)
+
+		const hashesAndItems: { [hash: string]: VizMSEPlayoutItemContentInstance } = {}
+
+		const expectedPlayoutItems = _.uniq(
+			_.filter(this._expectedPlayoutItems, (expectedPlayoutItem) => {
+				return (
+					(!this._preloadedRundownPlaylistId ||
+						!expectedPlayoutItem.playlistId ||
+						this._preloadedRundownPlaylistId === expectedPlayoutItem.playlistId) &&
+					(isVIZMSEPlayoutItemContentInternal(expectedPlayoutItem) ||
+						isVIZMSEPlayoutItemContentExternal(expectedPlayoutItem))
+				)
+			}),
+			false,
+			(a) => JSON.stringify(_.pick(a, 'templateName', 'templateData', 'vcpid', 'showId'))
+		)
+
+		await Promise.all(
+			_.map(expectedPlayoutItems, async (expectedPlayoutItem) => {
+				const content = this.getPlayoutItemContent(expectedPlayoutItem)
+				if (!content) {
+					return
+				}
+				const hash = VizMSEManager._getElementHash(content)
+				try {
+					await this._checkPrepareElement(content, true)
+					hashesAndItems[hash] = content
+				} catch (e) {
+					this.emit('error', `Error in _prepareAndGetExpectedPlayoutItems for "${hash}": ${(e as Error).toString()}`)
+				}
+			})
+		)
+		return hashesAndItems
+	}
+
+	/**
+	 * Update the load-statuses of the expectedPlayoutItems -elements from MSE, where needed
+	 */
+	private async updateElementsLoadedStatus(forceReloadAll?: boolean) {
+		const hashesAndItems = await this._prepareAndGetExpectedPlayoutItems()
+		let someUnloaded = false
+		const elementsToLoad = _.compact(
+			_.map(hashesAndItems, (item, hash) => {
+				const el = this._getCachedElement(hash)
+				if (!item.noAutoPreloading && el) {
+					if (el.wasLoaded && !el.isLoaded && !el.isLoading) {
+						someUnloaded = true
+					}
+					return el
+				}
+				return undefined
+			})
+		)
+		if (this._rundown) {
+			this.emit(
+				'debug',
+				`Updating status of elements starting, activePlaylistId="${
+					this._preloadedRundownPlaylistId
+				}", elementsToLoad.length=${elementsToLoad.length} (${_.keys(hashesAndItems).length})`
+			)
+
+			const rundown = await this._getRundown()
+
+			if (forceReloadAll) {
+				elementsToLoad.forEach((element) => {
+					element.isLoaded = false
+					element.isLoading = false
+					element.requestedLoading = false
+					element.wasLoaded = false
+				})
+			}
+			if (someUnloaded) {
+				await this._triggerRundownActivate(rundown)
+			}
+
+			await Promise.all(
+				_.map(elementsToLoad, async (cachedEl) => {
+					try {
+						await this._checkPrepareElement(cachedEl.content)
+
+						this.emit('debug', `Updating status of element ${cachedEl.hash}`)
+
+						// Update cached status of the element:
+						const newEl = await rundown.getElement(cachedEl.content)
+
+						const newLoadedEl = {
+							...cachedEl,
+							isExpected: true,
+							isLoaded: this._isElementLoaded(newEl),
+							isLoading: this._isElementLoading(newEl),
+						}
+						this._elementCache[cachedEl.hash] = newLoadedEl
+						this.emit('debug', `Element ${cachedEl.hash}: ${JSON.stringify(newEl)}`)
+						if (isVizMSEPlayoutItemContentExternalInstance(cachedEl.content)) {
+							if (this._updateAfterReconnect || cachedEl?.isLoaded !== newLoadedEl.isLoaded) {
+								if (cachedEl?.isLoaded && !newLoadedEl.isLoaded) {
+									newLoadedEl.wasLoaded = true
+								} else if (!cachedEl?.isLoaded && newLoadedEl.isLoaded) {
+									newLoadedEl.wasLoaded = false
+								}
+								const vcpid = cachedEl.content.vcpid
+								if (newLoadedEl.isLoaded) {
+									const mediaObject: MediaObject = {
+										_id: cachedEl.hash,
+										mediaId: 'PILOT_' + vcpid,
+										mediaPath: vcpid.toString(),
+										mediaSize: 0,
+										mediaTime: 0,
+										thumbSize: 0,
+										thumbTime: 0,
+										cinf: '',
+										tinf: '',
+										_rev: '',
+									}
+									this.emit('updateMediaObject', cachedEl.hash, mediaObject)
+								} else {
+									this.emit('updateMediaObject', cachedEl.hash, null)
+								}
+							}
+							if (newLoadedEl.wasLoaded && !newLoadedEl.isLoaded && !newLoadedEl.isLoading) {
+								this.emit(
+									'debug',
+									`Element "${this._getElementReference(newEl)}" went from loaded to not loaded, initializing`
+								)
+								await rundown.initialize(cachedEl.content)
+							}
+						}
+					} catch (e) {
+						this.emit('error', `Error in updateElementsLoadedStatus: ${(e as Error).toString()}`)
+					}
+				})
+			)
+			this._updateAfterReconnect = false
+			this.emit('debug', `Updating status of elements done`)
+		} else {
+			throw Error('VizMSE.v-connection not initialized yet')
+		}
+	}
+	private async _triggerRundownActivate(rundown: VRundown): Promise<void> {
+		try {
+			this.emit('debug', 'rundown.activate triggered')
+			await rundown.activate()
+		} catch (error) {
+			this.emit('warning', `Ignored error for rundown.activate(): ${error}`)
+		}
+		this._triggerCommandSent()
+		await this._wait(1000)
+		this._triggerCommandSent()
+	}
+	/**
+	 * Trigger a load of all elements that are not yet loaded onto the vizEngine.
+	 */
+	private async _triggerLoadAllElements(loadTwice = false): Promise<void> {
+		if (this._loadingAllElements) {
+			this.emit('warning', '_triggerLoadAllElements already running')
+			return
+		}
+		this._loadingAllElements = true
+		try {
+			const rundown = await this._getRundown()
+
+			this.emit('debug', '_triggerLoadAllElements starting')
+			// First, update the loading-status of all elements:
+			await this.updateElementsLoadedStatus(true)
+
+			// if (this._initializeRundownOnLoadAll) {
+			// Then, load all elements that needs loading:
+			const loadAllElementsThatNeedsLoading = async () => {
+				const showIdsToInitialize = new Set<string>()
+				this._triggerCommandSent()
+				await this._triggerRundownActivate(rundown)
+				await Promise.all(
+					_.map(this._elementCache, async (e) => {
+						if (isVizMSEPlayoutItemContentInternalInstance(e.content)) {
+							showIdsToInitialize.add(e.content.showId)
+							e.requestedLoading = true
+						} else if (isVizMSEPlayoutItemContentExternalInstance(e.content)) {
+							if (e.isLoaded) {
+								// The element is loaded fine, no need to do anything
+								this.emit('debug', `Element "${VizMSEManager._getElementHash(e.content)}" is loaded`)
+							} else if (e.isLoading) {
+								// The element is currently loading, do nothing
+								this.emit('debug', `Element "${VizMSEManager._getElementHash(e.content)}" is loading`)
+							} else if (e.isExpected) {
+								// The element has not started loading, load it:
+								this.emit('debug', `Element "${VizMSEManager._getElementHash(e.content)}" is not loaded, initializing`)
+								await rundown.initialize(e.content)
+							}
+						} else {
+							this.emit('error', `Element "${VizMSEManager._getElementHash(e.content)}" type `)
+						}
+					})
+				)
+				await this._initializeShows(Array.from(showIdsToInitialize))
+			}
+
+			// He's making a list:
+			await loadAllElementsThatNeedsLoading()
+			await this._wait(2000)
+			if (loadTwice) {
+				// He's checking it twice:
+				await this.updateElementsLoadedStatus()
+				// Gonna find out what's loaded and nice:
+				await loadAllElementsThatNeedsLoading()
+			}
+
+			this.emit('debug', '_triggerLoadAllElements done')
+		} finally {
+			this._loadingAllElements = false
+		}
+	}
+	private _setMonitorLoadedElementsTimeout(): void {
+		if (this._monitorAndLoadElementsTimeout) {
+			clearTimeout(this._monitorAndLoadElementsTimeout)
+		}
+		if (!this._terminated) {
+			this._monitorAndLoadElementsTimeout = setTimeout(() => {
+				this._monitorLoadedElements()
+					.catch((...args) => {
+						this.emit('error', ...args)
+					})
+					.finally(() => {
+						this._setMonitorLoadedElementsTimeout()
+					})
+			}, MONITOR_INTERVAL)
+		}
+	}
+	private _setMonitorConnectionTimeout(): void {
+		if (this._monitorMSEConnectionTimeout) {
+			clearTimeout(this._monitorMSEConnectionTimeout)
+		}
+		if (!this._terminated) {
+			this._monitorMSEConnectionTimeout = setTimeout(() => {
+				this._monitorConnection()
+					.catch((...args) => {
+						this.emit('error', ...args)
+					})
+					.finally(() => {
+						this._setMonitorConnectionTimeout()
+					})
+			}, MONITOR_INTERVAL)
+		}
+	}
+	private async _monitorConnection(): Promise<void> {
+		if (this.initialized) {
+			// (the ping will throw on a timeout if ping doesn't return in time)
+			return this._vizMSE
+				.ping()
+				.then(() => {
+					// ok!
+					if (!this._msePingConnected) {
+						this._msePingConnected = true
+						this.onConnectionChanged()
+					}
+				})
+				.catch(() => {
+					// not ok!
+					if (this._msePingConnected) {
+						this._msePingConnected = false
+						this.onConnectionChanged()
+					}
+				})
+				.then(async () => {
+					return this._msePingConnected ? this._monitorEngines() : Promise.resolve()
+				})
+		}
+		return Promise.reject()
+	}
+	private async _monitorEngines() {
+		if (!this.engineRestPort) {
+			return
+		}
+		const engines = await this._getEngines()
+		const ps: Promise<EngineStatus>[] = []
+		engines.forEach((engine) => {
+			return ps.push(this._pingEngine(engine))
+		})
+		const statuses = await Promise.all(ps)
+		const enginesDisconnected: string[] = []
+		statuses.forEach((status) => {
+			if (!status.alive) {
+				enginesDisconnected.push(`${status.channel || status.name} (${status.host})`)
+			}
+		})
+		if (!_.isEqual(enginesDisconnected, this.enginesDisconnected)) {
+			this.enginesDisconnected = enginesDisconnected
+			this.onConnectionChanged()
+		}
+	}
+	private async _pingEngine(engine: Engine): Promise<EngineStatus> {
+		return new Promise((resolve) => {
+			const url = `http://${engine.host}:${this.engineRestPort}/#/status`
+			request.get(url, { timeout: 2000 }, (error, response: request.Response | undefined) => {
+				const alive = !error && response !== undefined && response?.statusCode < 400
+				if (!alive) {
+					this.emit('debug', `VizMSE: _pingEngine at "${url}", error ${error}, code ${response?.statusCode}`)
+				}
+				resolve({ ...engine, alive })
+			})
+		})
+	}
+	/** Monitor loading status of expected elements */
+	private async _monitorLoadedElements(): Promise<void> {
+		try {
+			if (
+				this._rundown &&
+				this._hasActiveRundown &&
+				this.preloadAllElements &&
+				this._timeSinceLastCommandSent() > SAFE_PRELOAD_TIME
+			) {
+				await this.updateElementsLoadedStatus(false)
+
+				let notLoaded = 0
+				let loading = 0
+				let loaded = 0
+
+				_.each(this._elementCache, (e) => {
+					if (e.isLoaded) loaded++
+					else if (e.isLoading) loading++
+					else notLoaded++
+				})
+
+				if (notLoaded > 0 || loading > 0) {
+					// emit debug data
+					this.emit('debug', `Items on queue: notLoaded: ${notLoaded} loading: ${loading}, loaded: ${loaded}`)
+
+					this.emit(
+						'debug',
+						`_elementsLoaded: ${_.map(_.filter(this._elementCache, (e) => !e.isLoaded).slice(0, 10), (e) => {
+							return JSON.stringify(e.element)
+						})}`
+					)
+				}
+
+				this._setLoadedStatus(notLoaded, loading)
+			} else this._setLoadedStatus(0, 0)
+		} catch (e) {
+			this.emit('error', e)
+		}
+	}
+	private async _wait(time: number): Promise<void> {
+		if (this.ignoreAllWaits) return Promise.resolve()
+		return new Promise((resolve) => setTimeout(resolve, time))
+	}
+	/** Execute fcn an retry a couple of times until it succeeds */
+	private async _handleRetry<T>(fcn: () => Promise<T>): Promise<T> {
+		let i = 0
+		const maxNumberOfTries = 5
+
+		// eslint-disable-next-line no-constant-condition
+		while (true) {
+			try {
+				this._triggerCommandSent()
+				const result = fcn()
+				this._triggerCommandSent()
+				return result
+			} catch (e: any) {
+				if (i++ < maxNumberOfTries) {
+					if (e?.toString && e?.toString().match(/inexistent/i)) {
+						// "PepTalk inexistent error"
+						this.emit('debug', `VizMSE: _handleRetry got "inexistent" error, trying again...`)
+
+						// Wait and try again:
+						await this._wait(300)
+					} else {
+						// Unhandled error, give up:
+						throw e
+					}
+				} else {
+					// Give up, we've tried enough times already
+					throw e
+				}
+			}
+		}
+	}
+	private _triggerCommandSent(): void {
+		this._lastTimeCommandSent = Date.now()
+	}
+	private _timeSinceLastCommandSent(): number {
+		return Date.now() - this._lastTimeCommandSent
+	}
+	private _setLoadedStatus(notLoaded: number, loading: number) {
+		if (notLoaded !== this.notLoadedCount || loading !== this.loadingCount) {
+			this.notLoadedCount = notLoaded
+			this.loadingCount = loading
+			this._parentVizMSEDevice.connectionChanged()
+		}
+	}
+	/**
+	 * Returns true if the element is successfully loaded (as opposed to "not-loaded" or "loading")
+	 */
+	private _isElementLoaded(el: VElement): boolean {
+		if (this._isInternalElement(el)) {
+			return (
+				(el.available === '1.00' || el.available === '1' || el.available === undefined) &&
+				(el.loaded === '1.00' || el.loaded === '1') &&
+				el.is_loading !== 'yes'
+			)
+		} else if (this._isExternalElement(el)) {
+			return (
+				(el.available === '1.00' || el.available === '1') &&
+				(el.loaded === '1.00' || el.loaded === '1') &&
+				el.is_loading !== 'yes'
+			)
+		} else {
+			throw new Error(`vizMSE: _isLoaded: unknown element type: ${el && JSON.stringify(el)}`)
+		}
+	}
+	/**
+	 * Returns true if the element has NOT started loading (is currently not loading, or finished loaded)
+	 */
+	private _isElementLoading(el: VElement) {
+		if (this._isInternalElement(el)) {
+			return el.loaded !== '1.00' && el.loaded !== '1' && el.is_loading === 'yes'
+		} else if (this._isExternalElement(el)) {
+			return el.loaded !== '1.00' && el.loaded !== '1' && el.is_loading === 'yes'
+		} else {
+			throw new Error(`vizMSE: _isLoaded: unknown element type: ${el && JSON.stringify(el)}`)
+		}
+	}
+	/**
+	 * Return the current MSE rundown, create it if it doesn't exists
+	 */
+	private async _getRundown(): Promise<VRundown> {
+		if (!this._rundown) {
+			// Only allow for one rundown fetch at the same time:
+			if (this._getRundownPromise) {
+				return this._getRundownPromise
+			}
+
+			const getRundownPromise = (async () => {
+				// Check if the rundown already exists:
+				// let rundown: VRundown | undefined = _.find(await this._vizMSE.getRundowns(), (rundown) => {
+				// 	return (
+				// 		rundown.show === this._showID &&
+				// 		rundown.profile === this._profile &&
+				// 		rundown.playlist === this._playlistID
+				// 	)
+				// })
+				this.emit('debug', `Creating new rundown ${[this._profile, this._playlistID]}`)
+
+				const rundown = await this._vizMSE.createRundown(this._profile, this._playlistID)
+
+				this._rundown = rundown
+				if (!this._rundown) throw new Error(`_getRundown: this._rundown is not set!`)
+				return this._rundown
+			})()
+
+			this._getRundownPromise = getRundownPromise
+
+			try {
+				const rundown = await this._getRundownPromise
+				this._rundown = rundown
+				return rundown
+			} catch (e) {
+				this._getRundownPromise = undefined
+				throw e
+			}
+		} else {
+			return this._rundown
+		}
+	}
+	private mseConnectionChanged(connected: boolean) {
+		if (connected !== this._mseConnected) {
+			if (connected) {
+				// not the first connection
+				if (this._mseConnected === false) {
+					this._updateAfterReconnect = true
+				}
+			}
+			this._mseConnected = connected
+			this.onConnectionChanged()
+		}
+	}
+	private onConnectionChanged() {
+		this.emit('connectionChanged', this._mseConnected && this._msePingConnected)
+	}
+
+	public clearAllWaitWithLayer(portId: string) {
+		if (!this._waitWithLayers[portId]) {
+			_.each(this._waitWithLayers[portId], (fcn) => {
+				fcn(true)
+			})
+		}
+	}
+	/**
+	 * Returns true if the wait was cleared from someone else
+	 */
+	private async waitWithLayer(layerId: string, delay: number): Promise<boolean> {
+		return new Promise((resolve) => {
+			if (!this._waitWithLayers[layerId]) this._waitWithLayers[layerId] = []
+			this._waitWithLayers[layerId].push(resolve)
+			setTimeout(() => {
+				resolve(false)
+			}, delay || 0)
+		})
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1689,10 +1689,10 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
-"@tv2media/v-connection@^7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@tv2media/v-connection/-/v-connection-7.0.2.tgz#ddda77d687a961780b5d468f27aba61db4649566"
-  integrity sha512-KpqqrVuNrlKYe8wTw6QrmdvM95iQ8fRyKvIIfsJC741xfqi8PJtMR1ofmgxZ7CJDYQUVxxns01Luzv6bKYHI4Q==
+"@tv2media/v-connection@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@tv2media/v-connection/-/v-connection-7.1.0.tgz#e6b30c545afdd201e6c5ffafad9aa1af70a34c36"
+  integrity sha512-ikScIrfp5Ifrc6pJGDYTuV2Admvd5b3dQBrM0ez3qU5Ag6cosW5APv0Io6JvzAlXobkIy5ddjuHJ8nQvVMlhYg==
   dependencies:
     request "^2.88.2"
     request-promise-native "^1.0.9"


### PR DESCRIPTION
Note: not a draft, feel free to review, but it depends on https://github.com/tv2/v-connection/pull/51, so the tests in the CI won't pass before that other PR is merged+released and the version here is updated.

Makes use of the `/directory/shows` entry in the MSE.
Shows from now on are referenced in the timeline objects by their name (`showName`/`showNames` - breaking change - used to be `showId`/`showIds`), with the optional `showDirectoryPath` (an option of the TSR device) prepended.
Example: with `showDirectoryPath: 'SOFIE'` and `showName: 'overlay_shows/sample_show'`, we're looking for a show referenced under the following absolute path in the vdom: `/directory/shows/SOFIE/overlay_shows/sample_show.show`.

Refactors the implementation by moving some classes to separate files.