### PR TITLE
chore: make lerna respect breaking commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "docs": "yarn typedoc .",
     "postinstall": "lerna bootstrap",
     "release:set-version": "lerna version --exact --no-changelog --no-git-tag-version --no-push --yes",
-    "release:bump-release": "lerna version --exact --conventional-commits --conventional-graduate --tag-version-prefix='' --no-push --force-publish=*",
-    "release:bump-prerelease": "lerna version --exact --conventional-commits --conventional-prerelease --tag-version-prefix='' --no-push --force-publish=*",
+    "release:bump-release": "lerna version --exact --conventional-commits --changelog-preset conventionalcommits --conventional-graduate --tag-version-prefix='' --no-push --force-publish=*",
+    "release:bump-prerelease": "lerna version --exact --conventional-commits --changelog-preset conventionalcommits --conventional-prerelease --tag-version-prefix='' --no-push --force-publish=*",
     "validate:dependencies": "yarn lerna exec --parallel yarn validate:dependencies",
     "validate:dev-dependencies": "yarn lerna exec --parallel yarn validate:dev-dependencies",
     "rename-tv2": "yarn lerna run tv2-rename && git config user.name github-actions && git config user.email github-actions@github.com && git commit -a -m 'tmp'"
@@ -36,6 +36,7 @@
     "@types/underscore": "^1.10.24",
     "@types/ws": "^7.4.7",
     "@types/xml-js": "^1.0.0",
+    "conventional-changelog-conventionalcommits": "^5.0.0",
     "jest": "^26.0.1",
     "jest-haste-map": "^26.0.1",
     "jest-resolve": "^26.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3001,6 +3001,15 @@ conventional-changelog-angular@^5.0.12:
     compare-func "^2.0.0"
     q "^1.5.1"
 
+conventional-changelog-conventionalcommits@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz#41bdce54eb65a848a4a3ffdca93e92fa22b64a86"
+  integrity sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==
+  dependencies:
+    compare-func "^2.0.0"
+    lodash "^4.17.15"
+    q "^1.5.1"
+
 conventional-changelog-core@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-4.2.4.tgz#e50d047e8ebacf63fac3dc67bf918177001e1e9f"


### PR DESCRIPTION
Before, commits with exclamation mark (e.g. `feat!:`) were disregarded when bumping version and generating changelog, instead of being interpreted as breaking changes.
Uses a different changelog preset to fix it. See https://github.com/lerna/lerna/issues/2668#issuecomment-708632441
