### PR TITLE
fix: SOF-1254 control only resources that are mapped

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/index.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/index.spec.ts
@@ -58,13 +58,24 @@ describe('TriCasterDevice', () => {
 		})
 
 		expect(MOCK_SEND).not.toBeCalled()
+		const mappings = {
+			tc_me0_0: literal<MappingTriCaster>({
+				device: DeviceType.TRICASTER,
+				mappingType: MappingTriCasterType.ME,
+				name: 'main',
+				deviceId: 'tc0',
+			}),
+		}
 
-		device.handleState({ time: 11000, layers: {}, nextEvents: [] }, {})
+		device.handleState({ time: 11000, layers: {}, nextEvents: [] }, mappings)
 		await mockTime.advanceTimeToTicks(11010)
 
 		// check that initial commands are sent after connection
-		// the number of them is not that relevant
+		// the number of them is not that relevant, but they have to only affect the mapped resource
 		expect(MOCK_SEND).toBeCalled()
+		expect(MOCK_SEND.mock.calls.filter((call) => (call as any)[0].target.startsWith('main')).length).toEqual(
+			MOCK_SEND.mock.calls.length
+		)
 		MOCK_SEND.mockClear()
 
 		device.handleState(
@@ -84,14 +95,7 @@ describe('TriCasterDevice', () => {
 				},
 				nextEvents: [],
 			},
-			{
-				tc_me0_0: literal<MappingTriCaster>({
-					device: DeviceType.TRICASTER,
-					mappingType: MappingTriCasterType.ME,
-					name: 'main',
-					deviceId: 'tc0',
-				}),
-			}
+			mappings
 		)
 		await mockTime.advanceTimeToTicks(12010)
 		expect(MOCK_SEND).toHaveBeenCalledTimes(4)

--- a/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/triCasterTimelineStateConverter.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/triCasterTimelineStateConverter.spec.ts
@@ -158,8 +158,7 @@ describe('TimelineStateConverter.getTriCasterStateFromTimelineState', () => {
 					name: 'v1',
 					deviceId: 'tc0',
 				}),
-			},
-			'tc0'
+			}
 		)
 
 		const expectedState = mockGetDefaultState()
@@ -222,8 +221,7 @@ describe('TimelineStateConverter.getTriCasterStateFromTimelineState', () => {
 					name: 'out2',
 					deviceId: 'tc0',
 				}),
-			},
-			'tc0'
+			}
 		)
 
 		const expectedState = mockGetDefaultState()
@@ -259,8 +257,7 @@ describe('TimelineStateConverter.getTriCasterStateFromTimelineState', () => {
 					name: 'mix2',
 					deviceId: 'tc0',
 				}),
-			},
-			'tc0'
+			}
 		)
 
 		const expectedState = mockGetDefaultState()
@@ -299,8 +296,7 @@ describe('TimelineStateConverter.getTriCasterStateFromTimelineState', () => {
 					name: 'input2',
 					deviceId: 'tc0',
 				}),
-			},
-			'tc0'
+			}
 		)
 
 		const expectedState = mockGetDefaultState()

--- a/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/tricasterStateDiffer.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/tricasterStateDiffer.spec.ts
@@ -1,24 +1,43 @@
-import { DeviceType, MappingTriCaster, MappingTriCasterType as MappingType } from 'timeline-state-resolver-types'
+import { DeviceType, MappingTriCasterType as MappingType } from 'timeline-state-resolver-types'
 import { TriCasterInfo } from '../triCasterConnection'
-import { TriCasterStateDiffer } from '../triCasterStateDiffer'
+import { MappingsTriCaster, TriCasterStateDiffer } from '../triCasterStateDiffer'
 
 const MOCK_DEVICE_ID = 'tc0'
-const MOCK_MAPPINGS: MappingTriCaster[] = [
-	{ device: DeviceType.TRICASTER, mappingType: MappingType.ME, deviceId: MOCK_DEVICE_ID, name: 'main' },
-	{ device: DeviceType.TRICASTER, mappingType: MappingType.ME, deviceId: MOCK_DEVICE_ID, name: 'v1' },
-	{ device: DeviceType.TRICASTER, mappingType: MappingType.ME, deviceId: MOCK_DEVICE_ID, name: 'v2' },
-	{ device: DeviceType.TRICASTER, mappingType: MappingType.INPUT, deviceId: MOCK_DEVICE_ID, name: 'input1' },
-	{ device: DeviceType.TRICASTER, mappingType: MappingType.INPUT, deviceId: MOCK_DEVICE_ID, name: 'input2' },
-	{ device: DeviceType.TRICASTER, mappingType: MappingType.AUDIO_CHANNEL, deviceId: MOCK_DEVICE_ID, name: 'input1' },
-	{ device: DeviceType.TRICASTER, mappingType: MappingType.AUDIO_CHANNEL, deviceId: MOCK_DEVICE_ID, name: 'input2' },
-	{ device: DeviceType.TRICASTER, mappingType: MappingType.MIX_OUTPUT, deviceId: MOCK_DEVICE_ID, name: 'mix1' },
-	{ device: DeviceType.TRICASTER, mappingType: MappingType.MIX_OUTPUT, deviceId: MOCK_DEVICE_ID, name: 'mix2' },
-	{ device: DeviceType.TRICASTER, mappingType: MappingType.MATRIX_OUTPUT, deviceId: MOCK_DEVICE_ID, name: 'out1' },
-	{ device: DeviceType.TRICASTER, mappingType: MappingType.MATRIX_OUTPUT, deviceId: MOCK_DEVICE_ID, name: 'out2' },
-]
+const MOCK_MAPPINGS: MappingsTriCaster = {
+	main: { device: DeviceType.TRICASTER, mappingType: MappingType.ME, deviceId: MOCK_DEVICE_ID, name: 'main' },
+	v1: { device: DeviceType.TRICASTER, mappingType: MappingType.ME, deviceId: MOCK_DEVICE_ID, name: 'v1' },
+	v2: { device: DeviceType.TRICASTER, mappingType: MappingType.ME, deviceId: MOCK_DEVICE_ID, name: 'v2' },
+	input1: { device: DeviceType.TRICASTER, mappingType: MappingType.INPUT, deviceId: MOCK_DEVICE_ID, name: 'input1' },
+	input2: { device: DeviceType.TRICASTER, mappingType: MappingType.INPUT, deviceId: MOCK_DEVICE_ID, name: 'input2' },
+	audio_input1: {
+		device: DeviceType.TRICASTER,
+		mappingType: MappingType.AUDIO_CHANNEL,
+		deviceId: MOCK_DEVICE_ID,
+		name: 'input1',
+	},
+	audio_input2: {
+		device: DeviceType.TRICASTER,
+		mappingType: MappingType.AUDIO_CHANNEL,
+		deviceId: MOCK_DEVICE_ID,
+		name: 'input2',
+	},
+	mix1: { device: DeviceType.TRICASTER, mappingType: MappingType.MIX_OUTPUT, deviceId: MOCK_DEVICE_ID, name: 'mix1' },
+	mix2: { device: DeviceType.TRICASTER, mappingType: MappingType.MIX_OUTPUT, deviceId: MOCK_DEVICE_ID, name: 'mix2' },
+	out1: {
+		device: DeviceType.TRICASTER,
+		mappingType: MappingType.MATRIX_OUTPUT,
+		deviceId: MOCK_DEVICE_ID,
+		name: 'out1',
+	},
+	out2: {
+		device: DeviceType.TRICASTER,
+		mappingType: MappingType.MATRIX_OUTPUT,
+		deviceId: MOCK_DEVICE_ID,
+		name: 'out2',
+	},
+}
 
 function setupStateDiffer(oldMappings = MOCK_MAPPINGS, newMappings = MOCK_MAPPINGS) {
-	const deviceId = 'tc0'
 	const mockInfo: TriCasterInfo = {
 		inputCount: 2,
 		meCount: 2,
@@ -28,7 +47,7 @@ function setupStateDiffer(oldMappings = MOCK_MAPPINGS, newMappings = MOCK_MAPPIN
 		sessionName: 'TEST',
 		outputCount: 3,
 	}
-	const stateDiffer = new TriCasterStateDiffer(mockInfo, deviceId)
+	const stateDiffer = new TriCasterStateDiffer(mockInfo)
 
 	return {
 		stateDiffer,
@@ -527,8 +546,15 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 	describe('Mapping changes', () => {
 		test('added mapings generate commands with default state, only for the mapped resource', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer(
-				[],
-				[{ device: DeviceType.TRICASTER, mappingType: MappingType.MIX_OUTPUT, deviceId: MOCK_DEVICE_ID, name: 'mix1' }]
+				{},
+				{
+					mix1: {
+						device: DeviceType.TRICASTER,
+						mappingType: MappingType.MIX_OUTPUT,
+						deviceId: MOCK_DEVICE_ID,
+						name: 'mix1',
+					},
+				}
 			)
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
@@ -538,7 +564,7 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		})
 
 		test('removed mapings do not generate commands', () => {
-			const { stateDiffer, oldState, newState } = setupStateDiffer(MOCK_MAPPINGS, [])
+			const { stateDiffer, oldState, newState } = setupStateDiffer(MOCK_MAPPINGS, {})
 
 			// some example state
 			oldState.mixEffects.main.keyers.dsk2.transitionDuration = 5.2

--- a/packages/timeline-state-resolver/src/integrations/tricaster/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/index.ts
@@ -3,8 +3,14 @@ import { DeviceWithState, DeviceStatus, StatusCode } from './../../devices/devic
 import { DoOnTime, SendMode } from '../../devices/doOnTime'
 
 import { TimelineState } from 'superfly-timeline'
-import { DeviceType, Mappings, TriCasterOptions, DeviceOptionsTriCaster } from 'timeline-state-resolver-types'
-import { TriCasterState, TriCasterStateDiffer } from './triCasterStateDiffer'
+import {
+	DeviceType,
+	Mappings,
+	TriCasterOptions,
+	DeviceOptionsTriCaster,
+	MappingTriCaster,
+} from 'timeline-state-resolver-types'
+import { MappingsTriCaster, TriCasterState, TriCasterStateDiffer } from './triCasterStateDiffer'
 import { TriCasterCommandWithContext } from './triCasterCommands'
 import { TriCasterConnection } from './triCasterConnection'
 
@@ -37,7 +43,7 @@ export class TriCasterDevice extends DeviceWithState<TriCasterState, DeviceOptio
 		})
 		this._connection = new TriCasterConnection(options.host, options.port ?? DEFAULT_PORT)
 		this._connection.on('connected', (info, shortcutStateXml) => {
-			this._stateDiffer = new TriCasterStateDiffer(info, this.deviceId)
+			this._stateDiffer = new TriCasterStateDiffer(info)
 			this._setInitialState(shortcutStateXml)
 			this._setConnected(true)
 			this._initialized = true
@@ -85,6 +91,7 @@ export class TriCasterDevice extends DeviceWithState<TriCasterState, DeviceOptio
 	}
 
 	handleState(newState: TimelineState, newMappings: Mappings): void {
+		const triCasterMappings: MappingsTriCaster = this.filterTriCasterMappings(newMappings)
 		super.onHandleState(newState, newMappings)
 		if (!this._initialized || !this._stateDiffer) {
 			// before it's initialized don't do anything
@@ -94,12 +101,11 @@ export class TriCasterDevice extends DeviceWithState<TriCasterState, DeviceOptio
 
 		const previousStateTime = Math.max(this.getCurrentTime(), newState.time)
 		const oldState =
-			this.getStateBefore(previousStateTime)?.state ?? this._stateDiffer.getDefaultState(Object.values(newMappings))
+			this.getStateBefore(previousStateTime)?.state ?? this._stateDiffer.getDefaultState(triCasterMappings)
 
 		const newTriCasterState = this._stateDiffer.timelineStateConverter.getTriCasterStateFromTimelineState(
 			newState,
-			newMappings,
-			this.deviceId
+			triCasterMappings
 		)
 
 		const commandsToAchieveState = this._stateDiffer.getCommandsToAchieveState(newTriCasterState, oldState)
@@ -112,6 +118,15 @@ export class TriCasterDevice extends DeviceWithState<TriCasterState, DeviceOptio
 
 		// store the new state, for later use:
 		this.setState(newTriCasterState, newState.time)
+	}
+
+	private filterTriCasterMappings(newMappings: Mappings): MappingsTriCaster {
+		return Object.entries(newMappings).reduce<MappingsTriCaster>((accumulator, [layerName, mapping]) => {
+			if (mapping.device === DeviceType.TRICASTER && mapping.deviceId === this.deviceId) {
+				accumulator[layerName] = mapping as MappingTriCaster
+			}
+			return accumulator
+		}, {})
 	}
 
 	clearFuture(clearAfterTime: number): void {

--- a/packages/timeline-state-resolver/src/integrations/tricaster/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/index.ts
@@ -37,7 +37,7 @@ export class TriCasterDevice extends DeviceWithState<TriCasterState, DeviceOptio
 		})
 		this._connection = new TriCasterConnection(options.host, options.port ?? DEFAULT_PORT)
 		this._connection.on('connected', (info, shortcutStateXml) => {
-			this._stateDiffer = new TriCasterStateDiffer(info)
+			this._stateDiffer = new TriCasterStateDiffer(info, this.deviceId)
 			this._setInitialState(shortcutStateXml)
 			this._setConnected(true)
 			this._initialized = true
@@ -93,7 +93,8 @@ export class TriCasterDevice extends DeviceWithState<TriCasterState, DeviceOptio
 		}
 
 		const previousStateTime = Math.max(this.getCurrentTime(), newState.time)
-		const oldState = this.getStateBefore(previousStateTime)?.state ?? this._stateDiffer.getDefaultState()
+		const oldState =
+			this.getStateBefore(previousStateTime)?.state ?? this._stateDiffer.getDefaultState(Object.values(newMappings))
 
 		const newTriCasterState = this._stateDiffer.timelineStateConverter.getTriCasterStateFromTimelineState(
 			newState,

--- a/packages/timeline-state-resolver/src/integrations/tricaster/triCasterTimelineStateConverter.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/triCasterTimelineStateConverter.ts
@@ -21,6 +21,7 @@ import {
 	isTimelineObjTriCasterMatrixOutput,
 	TriCasterMatrixOutputName,
 	MappingTriCasterMatrixOutput,
+	Mapping,
 } from 'timeline-state-resolver-types'
 import * as _ from 'underscore'
 import { TriCasterState } from './triCasterStateDiffer'
@@ -35,7 +36,7 @@ export class TriCasterTimelineStateConverter {
 	private matrixOutputNames: Set<TriCasterMatrixOutputName>
 
 	constructor(
-		private readonly getDefaultState: () => TriCasterState,
+		private readonly getDefaultState: (mappings: Mapping[]) => TriCasterState,
 		resourceNames: {
 			mixEffects: TriCasterMixEffectName[]
 			inputs: TriCasterInputName[]
@@ -56,7 +57,7 @@ export class TriCasterTimelineStateConverter {
 		newMappings: Mappings,
 		deviceId: string
 	): TriCasterState {
-		const resultState = this.getDefaultState()
+		const resultState = this.getDefaultState(Object.values(newMappings))
 		const sortedLayers = this.sortLayers(timelineState)
 
 		_.each(sortedLayers, ({ tlObject, layerName }) => {


### PR DESCRIPTION
If there are no mappings defined for a resource, we will not send commands to it.

Also fixes a keyer bug that could have caused flipped state when mappings change on the fly (in one of the two scenarios only - the other is still left to be fixed)
