### PR TITLE
feat: SOF-1254 add me_clean support for mix outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ts-jest": "^26.1.0",
     "type-fest": "^2.16.0",
     "typedoc": "^0.22.14",
-    "typescript": "~4.5"
+    "typescript": "~4.9"
   },
   "prettier": "@sofie-automation/code-standard-preset/.prettierrc.json"
 }

--- a/packages/timeline-state-resolver-types/src/tricaster.ts
+++ b/packages/timeline-state-resolver-types/src/tricaster.ts
@@ -96,16 +96,19 @@ export type TimelineObjTriCasterAny =
 	| TimelineObjTriCasterMixOutput
 	| TimelineObjTriCasterMatrixOutput
 
+export interface TriCasterContentBase {
+	deviceType: DeviceType.TRICASTER
+	type: TimelineContentTypeTriCaster
+
+	/**
+	 * Priority used to sort commands that are supposed to execute at the same time
+	 * Lower means faster execution (analaogous to other device integrations)
+	 * Default: 0
+	 */
+	temporalPriority?: number
+}
 export interface TimelineObjTriCasterBase extends TSRTimelineObjBase {
-	content: {
-		deviceType: DeviceType.TRICASTER
-		type: TimelineContentTypeTriCaster
-		/**
-		 * Priority used to sort commands that are supposed to execute at the same time
-		 * Default: 0
-		 */
-		temporalPriority?: number
-	} & TimelineDatastoreReferencesContent
+	content: TriCasterContentBase & TimelineDatastoreReferencesContent
 }
 
 interface TriCasterMixEffectBase {
@@ -143,13 +146,10 @@ export type TriCasterMixEffect =
 	| TriCasterMixEffectInMixMode
 
 export interface TimelineObjTriCasterME extends TimelineObjTriCasterBase {
-	content: {
-		deviceType: DeviceType.TRICASTER
+	content: TriCasterContentBase & {
 		type: TimelineContentTypeTriCaster.ME
 
 		me: TriCasterMixEffect
-
-		temporalPriority?: number
 	} & TimelineDatastoreReferencesContent
 }
 
@@ -165,13 +165,10 @@ export function isTimelineObjTriCaster(timelineObject: TSRTimelineObjBase): time
  * Convenience object for the keyers in the Main M/E
  */
 export interface TimelineObjTriCasterDSK extends TimelineObjTriCasterBase {
-	content: {
-		deviceType: DeviceType.TRICASTER
+	content: TriCasterContentBase & {
 		type: TimelineContentTypeTriCaster.DSK
 
 		keyer: TriCasterKeyer
-
-		temporalPriority?: number
 	} & TimelineDatastoreReferencesContent
 }
 
@@ -187,13 +184,10 @@ export interface TriCasterInput {
 }
 
 export interface TimelineObjTriCasterInput extends TimelineObjTriCasterBase {
-	content: {
-		deviceType: DeviceType.TRICASTER
+	content: TriCasterContentBase & {
 		type: TimelineContentTypeTriCaster.INPUT
 
 		input: TriCasterInput
-
-		temporalPriority?: number
 	} & TimelineDatastoreReferencesContent
 }
 
@@ -213,13 +207,10 @@ export interface TriCasterAudioChannel {
 }
 
 export interface TimelineObjTriCasterAudioChannel extends TimelineObjTriCasterBase {
-	content: {
-		deviceType: DeviceType.TRICASTER
+	content: TriCasterContentBase & {
 		type: TimelineContentTypeTriCaster.AUDIO_CHANNEL
 
 		audioChannel: TriCasterAudioChannel
-
-		temporalPriority?: number
 	} & TimelineDatastoreReferencesContent
 }
 
@@ -235,8 +226,7 @@ export function isTimelineObjTriCasterAudioChannel(
  * Output usually referred to as Video Mix Output
  */
 export interface TimelineObjTriCasterMixOutput extends TimelineObjTriCasterBase {
-	content: {
-		deviceType: DeviceType.TRICASTER
+	content: TriCasterContentBase & {
 		type: TimelineContentTypeTriCaster.MIX_OUTPUT
 
 		/**
@@ -245,8 +235,6 @@ export interface TimelineObjTriCasterMixOutput extends TimelineObjTriCasterBase 
 		 * or 'program', 'preview', 'program_clean', 'me_program', 'me_preview'
 		 */
 		source: TriCasterMixOutputSource
-
-		temporalPriority?: number
 	} & TimelineDatastoreReferencesContent
 }
 
@@ -262,8 +250,7 @@ export function isTimelineObjTriCasterMixOutput(
  * Output from the Internal Matrix Router (crosspoint)
  */
 export interface TimelineObjTriCasterMatrixOutput extends TimelineObjTriCasterBase {
-	content: {
-		deviceType: DeviceType.TRICASTER
+	content: TriCasterContentBase & {
 		type: TimelineContentTypeTriCaster.MATRIX_OUTPUT
 
 		/**
@@ -271,8 +258,6 @@ export interface TimelineObjTriCasterMatrixOutput extends TimelineObjTriCasterBa
 		 * or mix outputs ('mixN') e.g. 'mix2'
 		 */
 		source: TriCasterMatrixOutputSource
-
-		temporalPriority?: number
 	} & TimelineDatastoreReferencesContent
 }
 

--- a/packages/timeline-state-resolver-types/src/tricaster.ts
+++ b/packages/timeline-state-resolver-types/src/tricaster.ts
@@ -235,6 +235,10 @@ export interface TimelineObjTriCasterMixOutput extends TimelineObjTriCasterBase 
 		 * or 'program', 'preview', 'program_clean', 'me_program', 'me_preview'
 		 */
 		source: TriCasterMixOutputSource
+		/**
+		 * Whether the clean version of the ME should be selected
+		 */
+		meClean?: boolean
 	} & TimelineDatastoreReferencesContent
 }
 

--- a/packages/timeline-state-resolver-types/src/tricaster.ts
+++ b/packages/timeline-state-resolver-types/src/tricaster.ts
@@ -100,6 +100,11 @@ export interface TimelineObjTriCasterBase extends TSRTimelineObjBase {
 	content: {
 		deviceType: DeviceType.TRICASTER
 		type: TimelineContentTypeTriCaster
+		/**
+		 * Priority used to sort commands that are supposed to execute at the same time
+		 * Default: 0
+		 */
+		temporalPriority?: number
 	} & TimelineDatastoreReferencesContent
 }
 
@@ -143,6 +148,8 @@ export interface TimelineObjTriCasterME extends TimelineObjTriCasterBase {
 		type: TimelineContentTypeTriCaster.ME
 
 		me: TriCasterMixEffect
+
+		temporalPriority?: number
 	} & TimelineDatastoreReferencesContent
 }
 
@@ -163,6 +170,8 @@ export interface TimelineObjTriCasterDSK extends TimelineObjTriCasterBase {
 		type: TimelineContentTypeTriCaster.DSK
 
 		keyer: TriCasterKeyer
+
+		temporalPriority?: number
 	} & TimelineDatastoreReferencesContent
 }
 
@@ -183,6 +192,8 @@ export interface TimelineObjTriCasterInput extends TimelineObjTriCasterBase {
 		type: TimelineContentTypeTriCaster.INPUT
 
 		input: TriCasterInput
+
+		temporalPriority?: number
 	} & TimelineDatastoreReferencesContent
 }
 
@@ -207,6 +218,8 @@ export interface TimelineObjTriCasterAudioChannel extends TimelineObjTriCasterBa
 		type: TimelineContentTypeTriCaster.AUDIO_CHANNEL
 
 		audioChannel: TriCasterAudioChannel
+
+		temporalPriority?: number
 	} & TimelineDatastoreReferencesContent
 }
 
@@ -232,6 +245,8 @@ export interface TimelineObjTriCasterMixOutput extends TimelineObjTriCasterBase 
 		 * or 'program', 'preview', 'program_clean', 'me_program', 'me_preview'
 		 */
 		source: TriCasterMixOutputSource
+
+		temporalPriority?: number
 	} & TimelineDatastoreReferencesContent
 }
 
@@ -256,6 +271,8 @@ export interface TimelineObjTriCasterMatrixOutput extends TimelineObjTriCasterBa
 		 * or mix outputs ('mixN') e.g. 'mix2'
 		 */
 		source: TriCasterMatrixOutputSource
+
+		temporalPriority?: number
 	} & TimelineDatastoreReferencesContent
 }
 

--- a/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/sisyfos/index.ts
@@ -15,7 +15,7 @@ import {
 
 import { DoOnTime, SendMode } from '../../devices/doOnTime'
 
-import { TimelineState, ResolvedTimelineObjectInstance } from 'superfly-timeline'
+import { TimelineState } from 'superfly-timeline'
 import {
 	SisyfosApi,
 	SisyfosCommand,
@@ -302,19 +302,19 @@ export class SisyfosMessageDevice extends DeviceWithState<SisyfosState, DeviceOp
 		} & SisyfosChannelOptions)[] = []
 
 		_.each(state.layers, (tlObject, layerName) => {
-			const layer = tlObject as ResolvedTimelineObjectInstance & TimelineObjSisyfosAny
+			const layer = tlObject as unknown as TimelineObjSisyfosAny
 			let foundMapping = mappings[layerName] as MappingSisyfos | undefined
 
 			const content = tlObject.content as TimelineObjSisyfosAny['content']
 
 			// Allow resync without valid channel mapping
-			if (layer.content.resync !== undefined) {
-				deviceState.resync = deviceState.resync || layer.content.resync
+			if ('resync' in content && content.resync !== undefined) {
+				deviceState.resync = deviceState.resync || content.resync
 			}
 
 			// Allow retrigger without valid channel mapping
-			if (layer.content.triggerValue !== undefined) {
-				deviceState.triggerValue = layer.content.triggerValue
+			if ('triggerValue' in content && content.triggerValue !== undefined) {
+				deviceState.triggerValue = content.triggerValue
 			}
 
 			// if the tlObj is specifies to load to PST the original Layer is used to resolve the mapping

--- a/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/triCasterCommands.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/triCasterCommands.spec.ts
@@ -23,6 +23,16 @@ describe('serializeToWebSocketMessage', () => {
 		expect(message).toEqual('name=main_a_row_named_input&value=input3')
 	})
 
+	test('serializes command with additional properties', () => {
+		const message = serializeToWebSocketMessage({
+			name: CommandName.SET_OUTPUT_CONFIG_VIDEO_SOURCE,
+			output_index: 2,
+			me_clean: false,
+		})
+
+		expect(message).toEqual('name=set_output_config_video_source&output_index=2&me_clean=false')
+	})
+
 	test('order of properties does not affect the output', () => {
 		const message = serializeToWebSocketMessage({
 			value: 'input3',

--- a/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/triCasterShortcutStateConverter.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/triCasterShortcutStateConverter.spec.ts
@@ -22,8 +22,8 @@ describe('TriCasterShortcutStateConverter.getTriCasterStateFromShortcutState', (
 	<shortcut_state name="main_b_row_named_input" value="DDR2" type="" sender="unknown"/>
 </shortcut_states>`)
 
-			expect(state.mixEffects['main'].programInput).toEqual('input7')
-			expect(state.mixEffects['main'].previewInput).toEqual('ddr2')
+			expect(state.mixEffects['main'].programInput).toEqual({ value: 'input7' })
+			expect(state.mixEffects['main'].previewInput).toEqual({ value: 'ddr2' })
 		})
 	})
 
@@ -38,10 +38,10 @@ describe('TriCasterShortcutStateConverter.getTriCasterStateFromShortcutState', (
 	<shortcut_state name="main_dsk4_value" value="0" type="double" sender="unknown" />
 </shortcut_states>`)
 
-			expect(state.mixEffects.main.keyers?.dsk1.onAir).toEqual(false)
-			expect(state.mixEffects.main.keyers?.dsk2.onAir).toEqual(true)
-			expect(state.mixEffects.main.keyers?.dsk3.onAir).toEqual(true)
-			expect(state.mixEffects.main.keyers?.dsk4.onAir).toEqual(false)
+			expect(state.mixEffects.main.keyers?.dsk1.onAir).toEqual({ value: false })
+			expect(state.mixEffects.main.keyers?.dsk2.onAir).toEqual({ value: true })
+			expect(state.mixEffects.main.keyers?.dsk3.onAir).toEqual({ value: true })
+			expect(state.mixEffects.main.keyers?.dsk4.onAir).toEqual({ value: false })
 		})
 
 		test('sets input', () => {
@@ -51,7 +51,7 @@ describe('TriCasterShortcutStateConverter.getTriCasterStateFromShortcutState', (
 	<shortcut_state name="main_dsk3_select_named_input" value="v6" type="" sender="unknown"/>
 </shortcut_states>`)
 
-			expect(state.mixEffects.main.keyers?.dsk3.input).toEqual('v6')
+			expect(state.mixEffects.main.keyers?.dsk3.input).toEqual({ value: 'v6' })
 		})
 	})
 
@@ -63,7 +63,7 @@ describe('TriCasterShortcutStateConverter.getTriCasterStateFromShortcutState', (
 	<shortcut_state name="v2_a_row_named_input" value="v6" type="" sender="unknown"/>
 </shortcut_states>`)
 
-			expect(state.mixEffects.v2.layers?.a?.input).toEqual('v6')
+			expect(state.mixEffects.v2.layers?.a?.input).toEqual({ value: 'v6' })
 		})
 	})
 
@@ -76,8 +76,8 @@ describe('TriCasterShortcutStateConverter.getTriCasterStateFromShortcutState', (
 	<shortcut_state name="mix2_output_source" value="me_preview" type="" sender="unknown"/>
 </shortcut_states>`)
 
-			expect(state.mixOutputs.mix1.source).toEqual('input7')
-			expect(state.mixOutputs.mix2.source).toEqual('me_preview')
+			expect(state.mixOutputs.mix1.source).toEqual({ value: 'input7' })
+			expect(state.mixOutputs.mix2.source).toEqual({ value: 'me_preview' })
 		})
 	})
 
@@ -90,8 +90,8 @@ describe('TriCasterShortcutStateConverter.getTriCasterStateFromShortcutState', (
 	<shortcut_state name="out2_crosspoint_source" value="mix2" type="" sender="unknown"/>
 </shortcut_states>`)
 
-			expect(state.matrixOutputs.out1.source).toEqual('input5')
-			expect(state.matrixOutputs.out2.source).toEqual('mix2')
+			expect(state.matrixOutputs.out1.source).toEqual({ value: 'input5' })
+			expect(state.matrixOutputs.out2.source).toEqual({ value: 'mix2' })
 		})
 	})
 })

--- a/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/triCasterTimelineStateConverter.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/triCasterTimelineStateConverter.spec.ts
@@ -15,7 +15,7 @@ import {
 	RequiredDeep,
 	TriCasterKeyerState,
 	TriCasterLayerState,
-	TriCasterState,
+	WithContext,
 	wrapStateInContext,
 } from '../triCasterStateDiffer'
 import { literal } from '../../../devices/device'
@@ -31,8 +31,8 @@ function setupTimelineStateConverter() {
 	})
 }
 
-const mockGetDefaultState = (): CompleteTriCasterState =>
-	wrapStateInContext<TriCasterState>({
+const mockGetDefaultState = (): WithContext<CompleteTriCasterState> =>
+	wrapStateInContext<CompleteTriCasterState>({
 		mixEffects: { main: mockGetDefaultMe(), v1: mockGetDefaultMe() }, // pretend we only have mappings for those two
 		inputs: {
 			input1: {
@@ -49,8 +49,8 @@ const mockGetDefaultState = (): CompleteTriCasterState =>
 		isRecording: false,
 		isStreaming: false,
 		mixOutputs: {
-			mix1: { source: 'program' },
-			mix2: { source: 'program' },
+			mix1: { source: 'program', meClean: false },
+			mix2: { source: 'program', meClean: false },
 		},
 		matrixOutputs: {
 			out1: { source: 'mix1' },
@@ -198,7 +198,7 @@ describe('TimelineStateConverter.getTriCasterStateFromTimelineState', () => {
 		expect(convertedState).toEqual(expectedState)
 	})
 
-	test('sets mix outputs', () => {
+	test('sets matrix outputs', () => {
 		const converter = setupTimelineStateConverter()
 
 		const convertedState = converter.getTriCasterStateFromTimelineState(
@@ -234,7 +234,7 @@ describe('TimelineStateConverter.getTriCasterStateFromTimelineState', () => {
 		expect(convertedState).toEqual(expectedState)
 	})
 
-	test('sets matrix outputs', () => {
+	test('sets mix outputs', () => {
 		const converter = setupTimelineStateConverter()
 
 		const convertedState = converter.getTriCasterStateFromTimelineState(
@@ -249,6 +249,7 @@ describe('TimelineStateConverter.getTriCasterStateFromTimelineState', () => {
 							deviceType: DeviceType.TRICASTER,
 							type: TimelineContentTypeTriCaster.MIX_OUTPUT,
 							source: 'me_program',
+							meClean: true,
 						},
 					}),
 				},
@@ -266,6 +267,7 @@ describe('TimelineStateConverter.getTriCasterStateFromTimelineState', () => {
 
 		const expectedState = mockGetDefaultState()
 		expectedState.mixOutputs.mix2.source = { value: 'me_program', timelineObjId: 't0' }
+		expectedState.mixOutputs.mix2.meClean = { value: true, timelineObjId: 't0' }
 
 		expect(convertedState).toEqual(expectedState)
 	})

--- a/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/triCasterTimelineStateConverter.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/triCasterTimelineStateConverter.spec.ts
@@ -16,7 +16,7 @@ import {
 	TriCasterKeyerState,
 	TriCasterLayerState,
 	TriCasterState,
-	wrapInExtendedState,
+	wrapStateInContext,
 } from '../triCasterStateDiffer'
 import { literal } from '../../../devices/device'
 import { wrapIntoResolvedInstance } from './helpers'
@@ -32,7 +32,7 @@ function setupTimelineStateConverter() {
 }
 
 const mockGetDefaultState = (): CompleteTriCasterState =>
-	wrapInExtendedState<TriCasterState>({
+	wrapStateInContext<TriCasterState>({
 		mixEffects: { main: mockGetDefaultMe(), v1: mockGetDefaultMe() }, // pretend we only have mappings for those two
 		inputs: {
 			input1: {
@@ -113,8 +113,8 @@ describe('TimelineStateConverter.getTriCasterStateFromTimelineState', () => {
 							me: { programInput: 'input2', previewInput: 'input3', transitionEffect: 5, transitionDuration: 20 },
 						},
 					}),
-					tc_me0_1: wrapIntoResolvedInstance<TimelineObjTriCasterME>({
-						layer: 'tc_me0_1',
+					tc_me1_0: wrapIntoResolvedInstance<TimelineObjTriCasterME>({
+						layer: 'tc_me1_0',
 						enable: { while: '1' },
 						id: 't1',
 						content: {
@@ -155,7 +155,7 @@ describe('TimelineStateConverter.getTriCasterStateFromTimelineState', () => {
 					name: 'main',
 					deviceId: 'tc0',
 				}),
-				tc_me0_1: literal<MappingTriCaster>({
+				tc_me1_0: literal<MappingTriCaster>({
 					device: DeviceType.TRICASTER,
 					mappingType: MappingTriCasterType.ME,
 					name: 'v1',
@@ -165,33 +165,33 @@ describe('TimelineStateConverter.getTriCasterStateFromTimelineState', () => {
 		)
 
 		const expectedState = mockGetDefaultState()
-		expectedState.mixEffects.main.programInput = { value: 'input2', timelineObjectId: 't0' }
-		expectedState.mixEffects.main.previewInput = { value: 'input3', timelineObjectId: 't0' }
-		expectedState.mixEffects.main.transitionEffect = { value: 5, timelineObjectId: 't0' }
-		expectedState.mixEffects.main.transitionDuration = { value: 20, timelineObjectId: 't0' }
-		expectedState.mixEffects.v1.keyers.dsk2.input = { value: 'input5', timelineObjectId: 't1' }
-		expectedState.mixEffects.v1.keyers.dsk2.onAir = { value: true, timelineObjectId: 't1' }
-		// @ts-ignore
+		expectedState.mixEffects.main.programInput = { value: 'input2', timelineObjId: 't0' }
+		expectedState.mixEffects.main.previewInput = { value: 'input3', timelineObjId: 't0' }
+		expectedState.mixEffects.main.transitionEffect = { value: 5, timelineObjId: 't0' }
+		expectedState.mixEffects.main.transitionDuration = { value: 20, timelineObjId: 't0' }
+		expectedState.mixEffects.v1.keyers.dsk2.input = { value: 'input5', timelineObjId: 't1' }
+		expectedState.mixEffects.v1.keyers.dsk2.onAir = { value: true, timelineObjId: 't1' }
+
 		expectedState.mixEffects.v1.layers!.b = {
-			input: { value: 'ddr3', timelineObjectId: 't1' },
+			input: { value: 'ddr3', timelineObjId: 't1' },
 			position: {
-				x: { value: 2, timelineObjectId: 't1' },
-				y: { value: -1.5, timelineObjectId: 't1' },
+				x: { value: 2, timelineObjId: 't1' },
+				y: { value: -1.5, timelineObjId: 't1' },
 			},
 			crop: {
-				left: { value: 5, timelineObjectId: 't1' },
-				right: { value: 10, timelineObjectId: 't1' },
-				up: { value: 1.1111, timelineObjectId: 't1' },
-				down: { value: 99.9, timelineObjectId: 't1' },
+				left: { value: 5, timelineObjId: 't1' },
+				right: { value: 10, timelineObjId: 't1' },
+				up: { value: 1.1111, timelineObjId: 't1' },
+				down: { value: 99.9, timelineObjId: 't1' },
 			},
-			scale: { x: { value: 200, timelineObjectId: 't1' }, y: { value: 90, timelineObjectId: 't1' } },
+			scale: { x: { value: 200, timelineObjId: 't1' }, y: { value: 90, timelineObjId: 't1' } },
 			rotation: {
-				x: { value: 1, timelineObjectId: 't1' },
-				y: { value: 2, timelineObjectId: 't1' },
-				z: { value: 3, timelineObjectId: 't1' },
+				x: { value: 1, timelineObjId: 't1' },
+				y: { value: 2, timelineObjId: 't1' },
+				z: { value: 3, timelineObjId: 't1' },
 			},
-			feather: { value: 67.67, timelineObjectId: 't1' },
-			positioningAndCropEnabled: { value: true, timelineObjectId: 't1' },
+			feather: { value: 67.67, timelineObjId: 't1' },
+			positioningAndCropEnabled: { value: true, timelineObjId: 't1' },
 		}
 		expectedState.mixEffects.v1.isInEffectMode.value = true
 
@@ -229,7 +229,7 @@ describe('TimelineStateConverter.getTriCasterStateFromTimelineState', () => {
 		)
 
 		const expectedState = mockGetDefaultState()
-		expectedState.matrixOutputs.out2.source = { value: 'input5', timelineObjectId: 't0' }
+		expectedState.matrixOutputs.out2.source = { value: 'input5', timelineObjId: 't0' }
 
 		expect(convertedState).toEqual(expectedState)
 	})
@@ -265,7 +265,7 @@ describe('TimelineStateConverter.getTriCasterStateFromTimelineState', () => {
 		)
 
 		const expectedState = mockGetDefaultState()
-		expectedState.mixOutputs.mix2.source = { value: 'me_program', timelineObjectId: 't0' }
+		expectedState.mixOutputs.mix2.source = { value: 'me_program', timelineObjId: 't0' }
 
 		expect(convertedState).toEqual(expectedState)
 	})
@@ -305,9 +305,69 @@ describe('TimelineStateConverter.getTriCasterStateFromTimelineState', () => {
 
 		const expectedState = mockGetDefaultState()
 		expectedState.inputs.input2 = {
-			videoSource: { value: 'Input 10', timelineObjectId: 't0' },
-			videoActAsAlpha: { value: true, timelineObjectId: 't0' },
+			videoSource: { value: 'Input 10', timelineObjId: 't0' },
+			videoActAsAlpha: { value: true, timelineObjId: 't0' },
 		}
+
+		expect(convertedState).toEqual(expectedState)
+	})
+
+	test('sets temporal priority', () => {
+		const converter = setupTimelineStateConverter()
+
+		const convertedState = converter.getTriCasterStateFromTimelineState(
+			{
+				time: Date.now(),
+				layers: {
+					tc_me0_0: wrapIntoResolvedInstance<TimelineObjTriCasterME>({
+						layer: 'tc_me0_0',
+						enable: { while: '1' },
+						id: 't0',
+						content: {
+							deviceType: DeviceType.TRICASTER,
+							type: TimelineContentTypeTriCaster.ME,
+							me: { programInput: 'input2', previewInput: 'input3', transitionEffect: 5, transitionDuration: 20 },
+						},
+					}),
+					tc_me0_1: wrapIntoResolvedInstance<TimelineObjTriCasterME>({
+						layer: 'tc_me0_1',
+						enable: { while: '1' },
+						id: 't1',
+						content: {
+							deviceType: DeviceType.TRICASTER,
+							type: TimelineContentTypeTriCaster.ME,
+							me: {
+								keyers: { dsk2: { onAir: true, input: 'input5' } },
+							},
+							temporalPriority: -1,
+						},
+					}),
+				},
+				nextEvents: [],
+			},
+			{
+				tc_me0_0: literal<MappingTriCaster>({
+					device: DeviceType.TRICASTER,
+					mappingType: MappingTriCasterType.ME,
+					name: 'main',
+					deviceId: 'tc0',
+				}),
+				tc_me0_1: literal<MappingTriCaster>({
+					device: DeviceType.TRICASTER,
+					mappingType: MappingTriCasterType.ME,
+					name: 'main',
+					deviceId: 'tc0',
+				}),
+			}
+		)
+
+		const expectedState = mockGetDefaultState()
+		expectedState.mixEffects.main.programInput = { value: 'input2', timelineObjId: 't0' }
+		expectedState.mixEffects.main.previewInput = { value: 'input3', timelineObjId: 't0' }
+		expectedState.mixEffects.main.transitionEffect = { value: 5, timelineObjId: 't0' }
+		expectedState.mixEffects.main.transitionDuration = { value: 20, timelineObjId: 't0' }
+		expectedState.mixEffects.main.keyers.dsk2.input = { value: 'input5', timelineObjId: 't1', temporalPriority: -1 }
+		expectedState.mixEffects.main.keyers.dsk2.onAir = { value: true, timelineObjId: 't1', temporalPriority: -1 }
 
 		expect(convertedState).toEqual(expectedState)
 	})

--- a/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/tricasterStateDiffer.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/tricasterStateDiffer.spec.ts
@@ -61,7 +61,7 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('changes main transition speed', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			newState.mixEffects.main.transitionDuration = 200
+			newState.mixEffects.main.transitionDuration.value = 200
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -72,10 +72,10 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('changes main transition effect to "fade", updating the speed even if it is the same', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.main.transitionDuration = 5.2
+			oldState.mixEffects.main.transitionDuration.value = 5.2
 
-			newState.mixEffects.main.transitionEffect = 'fade'
-			newState.mixEffects.main.transitionDuration = 5.2
+			newState.mixEffects.main.transitionEffect.value = 'fade'
+			newState.mixEffects.main.transitionDuration.value = 5.2
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -87,10 +87,10 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('changes main transition effect to numeric, updating the speed even if it is the same', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.main.transitionDuration = 5.2
+			oldState.mixEffects.main.transitionDuration.value = 5.2
 
-			newState.mixEffects.main.transitionEffect = 5
-			newState.mixEffects.main.transitionDuration = 5.2
+			newState.mixEffects.main.transitionEffect.value = 5
+			newState.mixEffects.main.transitionDuration.value = 5.2
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -102,12 +102,12 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('issues auto transition when program input changes and transition is not "cut"', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.main.transitionDuration = 5.2
-			oldState.mixEffects.main.programInput = 'input1'
+			oldState.mixEffects.main.transitionDuration.value = 5.2
+			oldState.mixEffects.main.programInput.value = 'input1'
 
-			newState.mixEffects.main.transitionDuration = 5.2
-			newState.mixEffects.main.transitionEffect = 5
-			newState.mixEffects.main.programInput = 'input5'
+			newState.mixEffects.main.transitionDuration.value = 5.2
+			newState.mixEffects.main.transitionEffect.value = 5
+			newState.mixEffects.main.programInput.value = 'input5'
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -121,11 +121,11 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('issues a take when program input changes and transition is "cut"', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.main.transitionEffect = 5
-			oldState.mixEffects.main.programInput = 'input1'
+			oldState.mixEffects.main.transitionEffect.value = 5
+			oldState.mixEffects.main.programInput.value = 'input1'
 
-			newState.mixEffects.main.transitionEffect = 'cut'
-			newState.mixEffects.main.programInput = 'input5'
+			newState.mixEffects.main.transitionEffect.value = 'cut'
+			newState.mixEffects.main.programInput.value = 'input5'
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -137,11 +137,11 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('changes program and preview when previewInput is provided', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.main.previewInput = 'input2'
-			oldState.mixEffects.main.programInput = 'input1'
+			oldState.mixEffects.main.previewInput!.value = 'input2'
+			oldState.mixEffects.main.programInput.value = 'input1'
 
-			newState.mixEffects.main.previewInput = 'input6'
-			newState.mixEffects.main.programInput = 'input5'
+			newState.mixEffects.main.previewInput!.value = 'input6'
+			newState.mixEffects.main.programInput.value = 'input5'
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -153,13 +153,13 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('does not change preview when transition is other than "cut"', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.main.previewInput = 'input2'
-			oldState.mixEffects.main.programInput = 'input1'
+			oldState.mixEffects.main.previewInput!.value = 'input2'
+			oldState.mixEffects.main.programInput.value = 'input1'
 
-			newState.mixEffects.main.transitionEffect = 5
-			newState.mixEffects.main.transitionDuration = 5.2
-			newState.mixEffects.main.previewInput = 'input6'
-			newState.mixEffects.main.programInput = 'input5'
+			newState.mixEffects.main.transitionEffect.value = 5
+			newState.mixEffects.main.transitionDuration.value = 5.2
+			newState.mixEffects.main.previewInput!.value = 'input6'
+			newState.mixEffects.main.programInput.value = 'input5'
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -173,9 +173,9 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('changes preview when program has no change', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.main.previewInput = 'input2'
+			oldState.mixEffects.main.previewInput!.value = 'input2'
 
-			newState.mixEffects.main.previewInput = 'input6'
+			newState.mixEffects.main.previewInput!.value = 'input6'
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -186,11 +186,11 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('sets delegates before a transition', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.main.programInput = 'input1'
-			oldState.mixEffects.main.delegates = ['dsk3', 'dsk4']
+			oldState.mixEffects.main.programInput.value = 'input1'
+			oldState.mixEffects.main.delegates.value = ['dsk3', 'dsk4']
 
-			newState.mixEffects.main.programInput = 'input2'
-			newState.mixEffects.main.delegates = ['dsk3', 'background']
+			newState.mixEffects.main.programInput.value = 'input2'
+			newState.mixEffects.main.delegates.value = ['dsk3', 'background']
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -205,9 +205,9 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('changes input when only the input changes', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.main.keyers.dsk2.input = 'input1'
+			oldState.mixEffects.main.keyers.dsk2.input.value = 'input1'
 
-			newState.mixEffects.main.keyers.dsk2.input = 'input2'
+			newState.mixEffects.main.keyers.dsk2.input.value = 'input2'
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -218,14 +218,14 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('issues auto transition when onAir changes and transition is not "cut"', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.main.keyers.dsk2.transitionDuration = 5.2
-			oldState.mixEffects.main.keyers.dsk2.transitionEffect = 5
-			oldState.mixEffects.main.keyers.dsk2.input = 'input1'
+			oldState.mixEffects.main.keyers.dsk2.transitionDuration.value = 5.2
+			oldState.mixEffects.main.keyers.dsk2.transitionEffect.value = 5
+			oldState.mixEffects.main.keyers.dsk2.input.value = 'input1'
 
-			newState.mixEffects.main.keyers.dsk2.transitionDuration = 5.2
-			newState.mixEffects.main.keyers.dsk2.transitionEffect = 5
-			newState.mixEffects.main.keyers.dsk2.onAir = true
-			newState.mixEffects.main.keyers.dsk2.input = 'input1'
+			newState.mixEffects.main.keyers.dsk2.transitionDuration.value = 5.2
+			newState.mixEffects.main.keyers.dsk2.transitionEffect.value = 5
+			newState.mixEffects.main.keyers.dsk2.onAir.value = true
+			newState.mixEffects.main.keyers.dsk2.input.value = 'input1'
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -236,12 +236,12 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('commands are in order when onAir and input change, and transition is not "cut"', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.main.keyers.dsk2.input = 'input1'
+			oldState.mixEffects.main.keyers.dsk2.input.value = 'input1'
 
-			newState.mixEffects.main.keyers.dsk2.transitionDuration = 5.2
-			newState.mixEffects.main.keyers.dsk2.transitionEffect = 5
-			newState.mixEffects.main.keyers.dsk2.onAir = true
-			newState.mixEffects.main.keyers.dsk2.input = 'input2'
+			newState.mixEffects.main.keyers.dsk2.transitionDuration.value = 5.2
+			newState.mixEffects.main.keyers.dsk2.transitionEffect.value = 5
+			newState.mixEffects.main.keyers.dsk2.onAir.value = true
+			newState.mixEffects.main.keyers.dsk2.input.value = 'input2'
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -255,8 +255,8 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('issues a value change when onAir changes and transition is "cut"', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			newState.mixEffects.main.keyers.dsk2.transitionEffect = 'cut'
-			newState.mixEffects.main.keyers.dsk2.onAir = true
+			newState.mixEffects.main.keyers.dsk2.transitionEffect.value = 'cut'
+			newState.mixEffects.main.keyers.dsk2.onAir.value = true
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -267,11 +267,11 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('commands are in order when when onAir and input changes and transition is "cut"', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.main.keyers.dsk2.input = 'input1'
+			oldState.mixEffects.main.keyers.dsk2.input.value = 'input1'
 
-			newState.mixEffects.main.keyers.dsk2.transitionEffect = 'cut'
-			newState.mixEffects.main.keyers.dsk2.onAir = true
-			newState.mixEffects.main.keyers.dsk2.input = 'input2'
+			newState.mixEffects.main.keyers.dsk2.transitionEffect.value = 'cut'
+			newState.mixEffects.main.keyers.dsk2.onAir.value = true
+			newState.mixEffects.main.keyers.dsk2.input.value = 'input2'
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -284,8 +284,8 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
 			newState.mixEffects.main.keyers.dsk2.position = {
-				x: 2.8,
-				y: -1,
+				x: { value: 2.8 },
+				y: { value: -1 },
 			}
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
@@ -299,8 +299,8 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
 			newState.mixEffects.main.keyers.dsk2.scale = {
-				x: 2.8,
-				y: -1,
+				x: { value: 2.8 },
+				y: { value: -1 },
 			}
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
@@ -314,9 +314,9 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
 			newState.mixEffects.main.keyers.dsk2.rotation = {
-				x: 2.8,
-				y: -1,
-				z: 5.0,
+				x: { value: 2.8 },
+				y: { value: -1 },
+				z: { value: 5.0 },
 			}
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
@@ -331,10 +331,10 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
 			newState.mixEffects.main.keyers.dsk2.crop = {
-				left: 10,
-				right: 50,
-				up: 25.67,
-				down: 99.9,
+				left: { value: 10 },
+				right: { value: 50 },
+				up: { value: 25.67 },
+				down: { value: 99.9 },
 			}
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
@@ -349,7 +349,7 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('generates feather commands', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			newState.mixEffects.main.keyers.dsk2.feather = 50
+			newState.mixEffects.main.keyers.dsk2.feather.value = 50
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -362,11 +362,11 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('preview change is discarded when layers are used', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.v1.previewInput = 'input1'
-			oldState.mixEffects.v1.isInEffectMode = true
+			oldState.mixEffects.v1.previewInput!.value = 'input1'
+			oldState.mixEffects.v1.isInEffectMode.value = true
 
-			newState.mixEffects.v1.previewInput = 'input2'
-			newState.mixEffects.v1.isInEffectMode = true
+			newState.mixEffects.v1.previewInput!.value = 'input2'
+			newState.mixEffects.v1.isInEffectMode.value = true
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -376,11 +376,11 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('program change is discarded when layers are used', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.v1.programInput = 'input1'
-			oldState.mixEffects.v1.isInEffectMode = true
+			oldState.mixEffects.v1.programInput.value = 'input1'
+			oldState.mixEffects.v1.isInEffectMode.value = true
 
-			newState.mixEffects.v1.programInput = 'input2'
-			newState.mixEffects.v1.isInEffectMode = true
+			newState.mixEffects.v1.programInput.value = 'input2'
+			newState.mixEffects.v1.isInEffectMode.value = true
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -390,11 +390,11 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('changes inputs', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.v1.layers!.a!.input = 'input1'
-			oldState.mixEffects.v1.isInEffectMode = true
+			oldState.mixEffects.v1.layers!.a!.input!.value = 'input1'
+			oldState.mixEffects.v1.isInEffectMode.value = true
 
-			newState.mixEffects.v1.layers!.a!.input = 'input2'
-			newState.mixEffects.v1.isInEffectMode = true
+			newState.mixEffects.v1.layers!.a!.input!.value = 'input2'
+			newState.mixEffects.v1.isInEffectMode.value = true
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -405,13 +405,13 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('does not change a or b inputs when not in effect mode', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.v1.layers!.a!.input = 'input1'
-			oldState.mixEffects.v1.layers!.b!.input = 'input3'
-			oldState.mixEffects.v1.isInEffectMode = false
+			oldState.mixEffects.v1.layers!.a!.input!.value = 'input1'
+			oldState.mixEffects.v1.layers!.b!.input!.value = 'input3'
+			oldState.mixEffects.v1.isInEffectMode.value = false
 
-			newState.mixEffects.v1.layers!.a!.input = 'input2'
-			newState.mixEffects.v1.layers!.b!.input = 'input4'
-			newState.mixEffects.v1.isInEffectMode = false
+			newState.mixEffects.v1.layers!.a!.input!.value = 'input2'
+			newState.mixEffects.v1.layers!.b!.input!.value = 'input4'
+			newState.mixEffects.v1.isInEffectMode.value = false
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -421,13 +421,13 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('generates position commands', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.v1.isInEffectMode = true
+			oldState.mixEffects.v1.isInEffectMode.value = true
 
 			newState.mixEffects.v1.layers!.a!.position = {
-				x: 2.8,
-				y: -1,
+				x: { value: 2.8 },
+				y: { value: -1 },
 			}
-			newState.mixEffects.v1.isInEffectMode = true
+			newState.mixEffects.v1.isInEffectMode.value = true
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -439,13 +439,13 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('generates scale commands', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.v1.isInEffectMode = true
+			oldState.mixEffects.v1.isInEffectMode.value = true
 
 			newState.mixEffects.v1.layers!.a!.scale = {
-				x: 2.8,
-				y: -1,
+				x: { value: 2.8 },
+				y: { value: -1 },
 			}
-			newState.mixEffects.v1.isInEffectMode = true
+			newState.mixEffects.v1.isInEffectMode.value = true
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -457,14 +457,14 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('generates rotation commands', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.v1.isInEffectMode = true
+			oldState.mixEffects.v1.isInEffectMode.value = true
 
 			newState.mixEffects.v1.layers!.a!.rotation = {
-				x: 2.8,
-				y: -1,
-				z: 5.0,
+				x: { value: 2.8 },
+				y: { value: -1 },
+				z: { value: 5.0 },
 			}
-			newState.mixEffects.v1.isInEffectMode = true
+			newState.mixEffects.v1.isInEffectMode.value = true
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -477,15 +477,15 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('generates crop commands', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.v1.isInEffectMode = true
+			oldState.mixEffects.v1.isInEffectMode.value = true
 
 			newState.mixEffects.v1.layers!.a!.crop = {
-				left: 10,
-				right: 50,
-				up: 25.67,
-				down: 99.9,
+				left: { value: 10 },
+				right: { value: 50 },
+				up: { value: 25.67 },
+				down: { value: 99.9 },
 			}
-			newState.mixEffects.v1.isInEffectMode = true
+			newState.mixEffects.v1.isInEffectMode.value = true
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -499,10 +499,10 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('generates feather commands', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.v1.isInEffectMode = true
+			oldState.mixEffects.v1.isInEffectMode.value = true
 
-			newState.mixEffects.v1.layers!.a!.feather = 50
-			newState.mixEffects.v1.isInEffectMode = true
+			newState.mixEffects.v1.layers!.a!.feather!.value = 50
+			newState.mixEffects.v1.isInEffectMode.value = true
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -513,9 +513,9 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('generates all commands when `isInEffectMode` changes to `true`', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			oldState.mixEffects.v1.isInEffectMode = false
+			oldState.mixEffects.v1.isInEffectMode.value = false
 
-			newState.mixEffects.v1.isInEffectMode = true
+			newState.mixEffects.v1.isInEffectMode.value = true
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -531,7 +531,7 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('sets act-as-alpha', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			newState.inputs.input2.videoActAsAlpha = true
+			newState.inputs.input2.videoActAsAlpha.value = true
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -542,7 +542,7 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('sets video source', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			newState.inputs.input2.videoSource = 'SOME-NETWORK-SOURCE (Output 1)'
+			newState.inputs.input2.videoSource!.value = 'SOME-NETWORK-SOURCE (Output 1)'
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -559,7 +559,7 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('unmutes', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			newState.audioChannels.input2.isMuted = false
+			newState.audioChannels.input2.isMuted.value = false
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -570,7 +570,7 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('sets volume', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			newState.audioChannels.input2.volume = 5
+			newState.audioChannels.input2.volume.value = 5
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -583,7 +583,7 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('sets output source', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			newState.mixOutputs.mix2.source = 'me_preview'
+			newState.mixOutputs.mix2.source.value = 'me_preview'
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -596,7 +596,7 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 		test('sets output source', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer()
 
-			newState.matrixOutputs.out2.source = 'input5'
+			newState.matrixOutputs.out2.source.value = 'input5'
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
@@ -629,9 +629,9 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 			const { stateDiffer, oldState, newState } = setupStateDiffer(MOCK_MAPPINGS, {})
 
 			// some example state
-			oldState.mixEffects.main.keyers.dsk2.transitionDuration = 5.2
-			oldState.mixEffects.main.keyers.dsk2.transitionEffect = 5
-			oldState.mixEffects.main.keyers.dsk2.input = 'input1'
+			oldState.mixEffects.main.keyers.dsk2.transitionDuration.value = 5.2
+			oldState.mixEffects.main.keyers.dsk2.transitionEffect.value = 5
+			oldState.mixEffects.main.keyers.dsk2.input.value = 'input1'
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 

--- a/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/tricasterStateDiffer.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/tricasterStateDiffer.spec.ts
@@ -590,6 +590,17 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 			expect(commands.length).toEqual(1)
 			expect(commands[0].command).toEqual({ target: 'mix2', name: '_output_source', value: 'me_preview' })
 		})
+
+		test('sets ME Clean', () => {
+			const { stateDiffer, oldState, newState } = setupStateDiffer()
+
+			newState.mixOutputs.mix2.meClean.value = true
+
+			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
+
+			expect(commands.length).toEqual(1)
+			expect(commands[0].command).toEqual({ name: 'set_output_config_video_source', output_index: 1, me_clean: true })
+		})
 	})
 
 	describe('Matrix Outputs', () => {
@@ -621,8 +632,9 @@ describe('TriCasterStateDiffer.getCommandsToAchieveState', () => {
 
 			const commands = stateDiffer.getCommandsToAchieveState(newState, oldState)
 
-			expect(commands.length).toEqual(1)
+			expect(commands.length).toEqual(2)
 			expect(commands[0].command).toEqual({ target: 'mix1', name: '_output_source', value: 'program' })
+			expect(commands[1].command).toEqual({ name: 'set_output_config_video_source', output_index: 0, me_clean: false })
 		})
 
 		test('removed mapings do not generate commands', () => {

--- a/packages/timeline-state-resolver/src/integrations/tricaster/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/index.ts
@@ -10,7 +10,7 @@ import {
 	DeviceOptionsTriCaster,
 	MappingTriCaster,
 } from 'timeline-state-resolver-types'
-import { ExtendedState, MappingsTriCaster, TriCasterState, TriCasterStateDiffer } from './triCasterStateDiffer'
+import { WithContext, MappingsTriCaster, TriCasterState, TriCasterStateDiffer } from './triCasterStateDiffer'
 import { TriCasterCommandWithContext } from './triCasterCommands'
 import { TriCasterConnection } from './triCasterConnection'
 
@@ -18,7 +18,7 @@ const DEFAULT_PORT = 5951
 
 export type DeviceOptionsTriCasterInternal = DeviceOptionsTriCaster
 
-export class TriCasterDevice extends DeviceWithState<ExtendedState<TriCasterState>, DeviceOptionsTriCasterInternal> {
+export class TriCasterDevice extends DeviceWithState<WithContext<TriCasterState>, DeviceOptionsTriCasterInternal> {
 	private _doOnTime: DoOnTime
 
 	private _resolveInitPromise: (value: boolean) => void

--- a/packages/timeline-state-resolver/src/integrations/tricaster/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/index.ts
@@ -10,7 +10,7 @@ import {
 	DeviceOptionsTriCaster,
 	MappingTriCaster,
 } from 'timeline-state-resolver-types'
-import { MappingsTriCaster, TriCasterState, TriCasterStateDiffer } from './triCasterStateDiffer'
+import { ExtendedState, MappingsTriCaster, TriCasterState, TriCasterStateDiffer } from './triCasterStateDiffer'
 import { TriCasterCommandWithContext } from './triCasterCommands'
 import { TriCasterConnection } from './triCasterConnection'
 
@@ -18,7 +18,7 @@ const DEFAULT_PORT = 5951
 
 export type DeviceOptionsTriCasterInternal = DeviceOptionsTriCaster
 
-export class TriCasterDevice extends DeviceWithState<TriCasterState, DeviceOptionsTriCasterInternal> {
+export class TriCasterDevice extends DeviceWithState<ExtendedState<TriCasterState>, DeviceOptionsTriCasterInternal> {
 	private _doOnTime: DoOnTime
 
 	private _resolveInitPromise: (value: boolean) => void

--- a/packages/timeline-state-resolver/src/integrations/tricaster/triCasterCommands.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/triCasterCommands.ts
@@ -164,8 +164,9 @@ export type TriCasterGenericCommandName<T> = T extends boolean
 export type TriCasterCommandContext = any
 export interface TriCasterCommandWithContext {
 	command: TriCasterCommand
-	context: TriCasterCommandContext
-	timelineObjId: string
+	context?: TriCasterCommandContext
+	timelineObjId?: string
+	temporalPriority: number
 }
 
 export function serializeToWebSocketMessage(command: TriCasterCommand): string {

--- a/packages/timeline-state-resolver/src/integrations/tricaster/triCasterCommands.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/triCasterCommands.ts
@@ -43,22 +43,25 @@ export enum CommandName {
 	// outputs
 	OUTPUT_SOURCE = '_output_source',
 	CROSSPOINT_SOURCE = '_crosspoint_source',
+	SET_OUTPUT_CONFIG_VIDEO_SOURCE = 'set_output_config_video_source',
 }
 
 export type ValueTypes = boolean | number | string
 
-type CommandWithValue<NameType extends CommandName, ValueType extends ValueTypes> = {
+interface Command<NameType extends CommandName> {
 	name: NameType
+}
+
+interface CommandWithValue<NameType extends CommandName, ValueType extends ValueTypes> extends Command<NameType> {
 	value: ValueType
 }
 
-type CommandWithTarget<NameType extends CommandName> = {
-	name: NameType
+interface CommandWithTarget<NameType extends CommandName> extends Command<NameType> {
 	target: string
 }
 
-type CommandWithValueAndTarget<NameType extends CommandName, ValueType extends ValueTypes> = {
-	name: NameType
+interface CommandWithValueAndTarget<NameType extends CommandName, ValueType extends ValueTypes>
+	extends Command<NameType> {
 	value: ValueType
 	target: string
 }
@@ -101,6 +104,10 @@ type StreamingToggle = CommandWithValue<CommandName.STREAMING_TOGGLE, number>
 
 type OutputSource = CommandWithValueAndTarget<CommandName.OUTPUT_SOURCE, string>
 type CrosspointSource = CommandWithValueAndTarget<CommandName.CROSSPOINT_SOURCE, string>
+interface OutputMeClean extends Command<CommandName.SET_OUTPUT_CONFIG_VIDEO_SOURCE> {
+	output_index: number
+	me_clean: boolean
+}
 
 export type TriCasterCommand =
 	| RowCommand
@@ -134,6 +141,7 @@ export type TriCasterCommand =
 	| StreamingToggle
 	| OutputSource
 	| CrosspointSource
+	| OutputMeClean
 
 type TriCasterGenericNumberCommand = Extract<
 	TriCasterCommand,

--- a/packages/timeline-state-resolver/src/integrations/tricaster/triCasterShortcutStateConverter.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/triCasterShortcutStateConverter.ts
@@ -16,10 +16,11 @@ import {
 	TriCasterInputState,
 	TriCasterKeyerState,
 	TriCasterLayerState,
-	TriCasterOutputState,
 	TriCasterState,
 	WithContext,
 	wrapStateInContext,
+	TriCasterMixOutputState,
+	TriCasterMatrixOutputState,
 } from './triCasterStateDiffer'
 import { CommandName, TriCasterGenericCommandName } from './triCasterCommands'
 
@@ -135,9 +136,9 @@ export class TriCasterShortcutStateConverter {
 
 	private parseMixOutputsState(
 		shortcutStates: ShortcutStates
-	): WithContext<Record<TriCasterMixOutputName, TriCasterOutputState>> {
+	): WithContext<Record<TriCasterMixOutputName, TriCasterMixOutputState>> {
 		return fillRecord(this.resourceNames.mixOutputs, (mixOutputName) =>
-			wrapStateInContext<TriCasterOutputState>({
+			wrapStateInContext<TriCasterMixOutputState>({
 				source: this.parseString(shortcutStates, [mixOutputName], CommandName.OUTPUT_SOURCE)?.toLowerCase(),
 			})
 		)
@@ -145,9 +146,9 @@ export class TriCasterShortcutStateConverter {
 
 	private parseMatrixOutputsState(
 		shortcutStates: ShortcutStates
-	): WithContext<Record<TriCasterMatrixOutputName, TriCasterOutputState>> {
+	): WithContext<Record<TriCasterMatrixOutputName, TriCasterMatrixOutputState>> {
 		return fillRecord(this.resourceNames.matrixOutputs, (matrixOutputName) =>
-			wrapStateInContext<TriCasterOutputState>({
+			wrapStateInContext<TriCasterMatrixOutputState>({
 				source: this.parseString(shortcutStates, [matrixOutputName], CommandName.CROSSPOINT_SOURCE)?.toLowerCase(),
 			})
 		)

--- a/packages/timeline-state-resolver/src/integrations/tricaster/triCasterTimelineStateConverter.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/triCasterTimelineStateConverter.ts
@@ -165,6 +165,14 @@ export class TriCasterTimelineStateConverter {
 				timelineObjId: tlObject.id,
 				temporalPriority: tlObject.content.temporalPriority,
 			},
+			meClean:
+				tlObject.content.meClean !== undefined
+					? {
+							value: tlObject.content.meClean,
+							timelineObjId: tlObject.id,
+							temporalPriority: tlObject.content.temporalPriority,
+					  }
+					: resultState.mixOutputs[mapping.name]?.meClean,
 		}
 	}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8476,10 +8476,10 @@ typedoc@^0.22.14:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
   integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
-typescript@~4.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+typescript@~4.9:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 uglify-js@^3.1.4:
   version "3.17.2"


### PR DESCRIPTION
Allows selecting for the chosen ME whether to use clean signal or not

Based on https://github.com/tv2/tv-automation-state-timeline-resolver/pull/50 (waiting for that one to get merged), this starts from 7f3fb9c7d9edb03022db69c6e206302c5c69a815