### PR TITLE
fix: SOF-1404 use upstreamKeyerId to address ATEM upstream keyers

### DIFF
--- a/packages/timeline-state-resolver/src/integrations/atem/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/atem/index.ts
@@ -262,10 +262,10 @@ export class AtemDevice extends DeviceWithState<DeviceState, DeviceOptionsAtemIn
 									me.transitionProperties.nextStyle = transition as number as ConnectionEnums.TransitionStyle
 								}
 								if (atemObjKeyers) {
-									_.each(atemObjKeyers, (objKey, i) => {
-										const keyer = AtemStateUtil.getUpstreamKeyer(me, i)
-										deepExtend(keyer, objKey)
-									})
+									for (const objKeyer of atemObjKeyers) {
+										const keyer = AtemStateUtil.getUpstreamKeyer(me, objKeyer.upstreamKeyerId)
+										deepExtend(keyer, objKeyer)
+									}
 								}
 							}
 							break


### PR DESCRIPTION
Makes passing empty upstream keyer objects no longer needed - the array may contain only the USKs that are actually meant to be controlled