### PR TITLE
feat: no-defaults TriCaster

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.5.0",
+	"version": "3.5.0-test-no-defaults",
 	"npmClient": "yarn",
 	"useWorkspaces": true
 }

--- a/packages/timeline-state-resolver-types/package.json
+++ b/packages/timeline-state-resolver-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "timeline-state-resolver-types",
-	"version": "3.5.0",
+	"version": "3.5.0-test-no-defaults",
 	"description": "Have timeline, control stuff",
 	"main": "dist/index.js",
 	"typings": "dist/index.d.ts",

--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "timeline-state-resolver",
-	"version": "3.5.0",
+	"version": "3.5.0-test-no-defaults",
 	"description": "Have timeline, control stuff",
 	"main": "dist/index.js",
 	"typings": "dist/index.d.ts",
@@ -77,7 +77,7 @@
 		"sprintf-js": "^1.1.2",
 		"superfly-timeline": "^8.3.1",
 		"threadedclass": "^1.1.1",
-		"timeline-state-resolver-types": "3.5.0",
+		"timeline-state-resolver-types": "3.5.0-test-no-defaults",
 		"tslib": "^2.3.1",
 		"tv-automation-quantel-gateway-client": "^2.0.5",
 		"underscore": "^1.13.4",

--- a/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/helpers.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/helpers.ts
@@ -1,4 +1,25 @@
 import { TimelineObject, ResolvedTimelineObjectInstance } from 'superfly-timeline'
+import { TriCasterResourceNames } from '../triCasterInfoParser'
+import {
+	WithContext,
+	CompleteTriCasterState,
+	wrapStateInContext,
+	CompleteTriCasterMixEffectState,
+	RequiredDeep,
+	TriCasterKeyerState,
+	TriCasterLayerState,
+	TriCasterState,
+} from '../triCasterStateDiffer'
+
+export const MOCK_RESOURCES: TriCasterResourceNames = {
+	mixEffects: ['main', 'v1', 'v2'],
+	inputs: ['input1', 'input2'],
+	audioChannels: ['input1', 'input2', 'sound', 'master'],
+	layers: ['a', 'b'],
+	keyers: ['dsk1', 'dsk2', 'dsk3', 'dsk4'],
+	mixOutputs: ['mix1', 'mix2'],
+	matrixOutputs: ['out1', 'out2'],
+}
 
 export const wrapIntoResolvedInstance = <T extends TimelineObject>(
 	timelineObject: T
@@ -12,3 +33,86 @@ export const wrapIntoResolvedInstance = <T extends TimelineObject>(
 	},
 	instance: { start: 0, end: Infinity, id: timelineObject.id, references: [] },
 })
+
+export const mockGetDefaultState = (): WithContext<CompleteTriCasterState> =>
+	wrapStateInContext<CompleteTriCasterState>({
+		mixEffects: { main: mockGetDefaultMe(), v1: mockGetDefaultMe() }, // pretend we only have mappings for those two
+		inputs: {
+			input1: {
+				videoActAsAlpha: false,
+				videoSource: undefined,
+			},
+			input2: {
+				videoActAsAlpha: false,
+				videoSource: undefined,
+			},
+		},
+		// @ts-ignore for now
+		audioChannels: {
+			input1: { isMuted: true, volume: 0 },
+			input2: { isMuted: true, volume: 0 },
+		},
+		isRecording: false,
+		isStreaming: false,
+		mixOutputs: {
+			mix1: { source: 'program', meClean: false },
+			mix2: { source: 'program', meClean: false },
+		},
+		matrixOutputs: {
+			out1: { source: 'mix1' },
+			out2: { source: 'mix1' },
+		},
+	})
+
+export const mockGetDefaultMainMe = (): CompleteTriCasterMixEffectState => ({
+	programInput: 'black',
+	previewInput: undefined,
+	transitionEffect: 'cut',
+	transitionDuration: 1,
+	layers: {},
+	keyers: {
+		dsk1: mockGetDefaultKeyer(),
+		dsk2: mockGetDefaultKeyer(),
+	},
+	delegates: ['background'],
+	isInEffectMode: false,
+})
+
+export const mockGetDefaultMe = (): CompleteTriCasterMixEffectState => ({
+	...mockGetDefaultMainMe(),
+	layers: { a: mockGetDefaultLayer(), b: mockGetDefaultLayer() },
+})
+
+export const mockGetDefaultKeyer = (): RequiredDeep<TriCasterKeyerState> => ({
+	input: 'black',
+	positioningAndCropEnabled: false,
+	position: { x: 0, y: 0 },
+	scale: { x: 1, y: 1 },
+	rotation: { x: 0, y: 0, z: 0 },
+	crop: { left: 0, right: 0, up: 0, down: 0 },
+	onAir: false,
+	transitionEffect: 'cut',
+	transitionDuration: 1,
+	feather: 0,
+})
+
+export const mockGetDefaultLayer = (): TriCasterLayerState => ({
+	input: 'black',
+	positioningAndCropEnabled: false,
+	position: { x: 0, y: 0 },
+	scale: { x: 1, y: 1 },
+	rotation: { x: 0, y: 0, z: 0 },
+	crop: { left: 0, right: 0, up: 0, down: 0 },
+	feather: 0,
+})
+
+export const mockGetBlankState = (): WithContext<TriCasterState> =>
+	wrapStateInContext<TriCasterState>({
+		mixEffects: {},
+		inputs: {},
+		audioChannels: {},
+		isRecording: false,
+		isStreaming: false,
+		mixOutputs: {},
+		matrixOutputs: {},
+	})

--- a/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/triCasterInfoParser.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/triCasterInfoParser.spec.ts
@@ -25,6 +25,34 @@ describe('TriCasterInfoParser', () => {
 			outputCount: 8,
 		})
 	})
+
+	test('getAvailableResources returns resource names', () => {
+		const parser = new TriCasterInfoParser()
+
+		const resources = parser.getAvailableResources(
+			{
+				inputCount: 4,
+				dskCount: 3,
+				meCount: 2,
+				ddrCount: 3,
+			},
+			{
+				productModel: 'TC2ELITE',
+				sessionName: 'TEST SESSION',
+				outputCount: 5,
+			}
+		)
+
+		expect(resources).toEqual({
+			mixEffects: ['main', 'v1', 'v2'],
+			inputs: ['input1', 'input2', 'input3', 'input4'],
+			audioChannels: ['ddr1', 'ddr2', 'ddr3', 'sound', 'master', 'input1', 'input2', 'input3', 'input4'],
+			layers: ['a', 'b', 'c', 'd'],
+			keyers: ['dsk1', 'dsk2', 'dsk3'],
+			mixOutputs: ['mix1', 'mix2', 'mix3', 'mix4', 'mix5'],
+			matrixOutputs: ['out1', 'out2', 'out3', 'out4', 'out5', 'out6', 'out7', 'out8'],
+		})
+	})
 })
 
 const MOCK_SWITCHER_UPDATE = `<switcher_update main_source="INPUT2" preview_source="INPUT9" effect="C:\\ProgramData\\NewTek\\Effects\\Transitions\\Fades\\Non Additive Fade.trans" iso_label="INPUT 9" button_label="9">

--- a/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/triCasterShortcutStateConverter.spec.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/__tests__/triCasterShortcutStateConverter.spec.ts
@@ -1,15 +1,8 @@
 import { TriCasterShortcutStateConverter } from '../triCasterShortcutStateConverter'
+import { MOCK_RESOURCES } from './helpers'
 
 function setUpShortcutStateConverter() {
-	return new TriCasterShortcutStateConverter({
-		mixEffects: ['main', 'v1', 'v2'],
-		inputs: ['input1', 'input2'],
-		audioChannels: ['input1', 'input2', 'sound', 'master'],
-		layers: ['a', 'b'],
-		keyers: ['dsk1', 'dsk2', 'dsk3', 'dsk4'],
-		mixOutputs: ['mix1', 'mix2'],
-		matrixOutputs: ['out1', 'out2'],
-	})
+	return new TriCasterShortcutStateConverter(MOCK_RESOURCES)
 }
 
 describe('TriCasterShortcutStateConverter.getTriCasterStateFromShortcutState', () => {
@@ -22,8 +15,8 @@ describe('TriCasterShortcutStateConverter.getTriCasterStateFromShortcutState', (
 	<shortcut_state name="main_b_row_named_input" value="DDR2" type="" sender="unknown"/>
 </shortcut_states>`)
 
-			expect(state.mixEffects['main'].programInput).toEqual({ value: 'input7' })
-			expect(state.mixEffects['main'].previewInput).toEqual({ value: 'ddr2' })
+			expect(state.mixEffects['main']?.programInput).toEqual({ value: 'input7' })
+			expect(state.mixEffects['main']?.previewInput).toEqual({ value: 'ddr2' })
 		})
 	})
 
@@ -38,10 +31,10 @@ describe('TriCasterShortcutStateConverter.getTriCasterStateFromShortcutState', (
 	<shortcut_state name="main_dsk4_value" value="0" type="double" sender="unknown" />
 </shortcut_states>`)
 
-			expect(state.mixEffects.main.keyers?.dsk1.onAir).toEqual({ value: false })
-			expect(state.mixEffects.main.keyers?.dsk2.onAir).toEqual({ value: true })
-			expect(state.mixEffects.main.keyers?.dsk3.onAir).toEqual({ value: true })
-			expect(state.mixEffects.main.keyers?.dsk4.onAir).toEqual({ value: false })
+			expect(state.mixEffects.main?.keyers?.dsk1.onAir).toEqual({ value: false })
+			expect(state.mixEffects.main?.keyers?.dsk2.onAir).toEqual({ value: true })
+			expect(state.mixEffects.main?.keyers?.dsk3.onAir).toEqual({ value: true })
+			expect(state.mixEffects.main?.keyers?.dsk4.onAir).toEqual({ value: false })
 		})
 
 		test('sets input', () => {
@@ -51,7 +44,7 @@ describe('TriCasterShortcutStateConverter.getTriCasterStateFromShortcutState', (
 	<shortcut_state name="main_dsk3_select_named_input" value="v6" type="" sender="unknown"/>
 </shortcut_states>`)
 
-			expect(state.mixEffects.main.keyers?.dsk3.input).toEqual({ value: 'v6' })
+			expect(state.mixEffects.main?.keyers?.dsk3.input).toEqual({ value: 'v6' })
 		})
 	})
 
@@ -63,7 +56,7 @@ describe('TriCasterShortcutStateConverter.getTriCasterStateFromShortcutState', (
 	<shortcut_state name="v2_a_row_named_input" value="v6" type="" sender="unknown"/>
 </shortcut_states>`)
 
-			expect(state.mixEffects.v2.layers?.a?.input).toEqual({ value: 'v6' })
+			expect(state.mixEffects.v2?.layers?.a?.input).toEqual({ value: 'v6' })
 		})
 	})
 

--- a/packages/timeline-state-resolver/src/integrations/tricaster/triCasterShortcutStateConverter.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/triCasterShortcutStateConverter.ts
@@ -10,7 +10,6 @@ import {
 } from 'timeline-state-resolver-types'
 import { ElementCompact, xml2js } from 'xml-js'
 import {
-	fillRecord,
 	TriCasterMixEffectState,
 	TriCasterAudioChannelState,
 	TriCasterInputState,
@@ -23,23 +22,15 @@ import {
 	TriCasterMatrixOutputState,
 } from './triCasterStateDiffer'
 import { CommandName, TriCasterGenericCommandName } from './triCasterCommands'
+import { TriCasterResourceNames } from './triCasterInfoParser'
+import { fillRecord } from './util'
 
 type ShortcutStates = {
 	[key: string]: string | number
 }
 
 export class TriCasterShortcutStateConverter {
-	constructor(
-		private readonly resourceNames: {
-			mixEffects: TriCasterMixEffectName[]
-			inputs: TriCasterInputName[]
-			audioChannels: TriCasterAudioChannelName[]
-			layers: TriCasterLayerName[]
-			keyers: TriCasterKeyerName[]
-			mixOutputs: TriCasterMixOutputName[]
-			matrixOutputs: TriCasterMatrixOutputName[]
-		}
-	) {}
+	constructor(private readonly resourceNames: TriCasterResourceNames) {}
 
 	getTriCasterStateFromShortcutState(shortcutStatesXml: string): WithContext<TriCasterState> {
 		const parsedStates = xml2js(shortcutStatesXml, { compact: true }) as ElementCompact

--- a/packages/timeline-state-resolver/src/integrations/tricaster/util.ts
+++ b/packages/timeline-state-resolver/src/integrations/tricaster/util.ts
@@ -1,0 +1,16 @@
+export function fillArray<T>(length: number, mapFn: (index: number) => T): T[]
+export function fillArray<T>(length: number, value: T): T[]
+export function fillArray<T>(length: number, valueOrMapFn: T | ((index: number) => T)): T[] {
+	return valueOrMapFn instanceof Function
+		? Array.from({ length }, (_, i) => valueOrMapFn(i))
+		: new Array(length).fill(valueOrMapFn)
+}
+
+export function fillRecord<T extends string, U>(keys: T[], mapFn: (key: T) => U): Record<T, U>
+export function fillRecord<T extends string, U>(keys: T[], value: U): Record<T, U>
+export function fillRecord<T extends string, U>(keys: T[], valueOrMapFn: U | ((key: T) => U)): Record<T, U> {
+	return keys.reduce((accumulator, key) => {
+		accumulator[key] = valueOrMapFn instanceof Function ? valueOrMapFn(key) : valueOrMapFn
+		return accumulator
+	}, {} as Record<T, U>)
+}


### PR DESCRIPTION
Not ready for review yet.
This is a draft to indicate existence of these changes, which make the default values for controlled resources to be applied only when a timeline object exists on a mapping targeting particular resource. This allows Sofie to have empty baseline, so that deactivation and activation happens without sending any commands. Drawback: excessive commands may be generated when a timeline object first appears on a layer.