### PR TITLE
SOF-1814 - Keep TCP socket alive

### DIFF
--- a/packages/timeline-state-resolver/src/devices/__tests__/telemetrics.spec.ts
+++ b/packages/timeline-state-resolver/src/devices/__tests__/telemetrics.spec.ts
@@ -11,6 +11,7 @@ jest.spyOn(global, 'setTimeout')
 
 const SERVER_PORT = 5000
 const SERVER_HOST = '1.1.1.1'
+const SESSION_KEEPER_INTERVAL_MS = 1990
 const EMPTY_COMMAND_HEX = '0D'
 
 const MOCKED_SOCKET_START_KEEP_ALIVE = jest.fn()
@@ -89,7 +90,7 @@ describe('telemetrics', () => {
 			device = createInitializedTelemetricsDevice()
 			SOCKET_EVENTS.get('ready')!()
 
-			expect(setTimeout).toBeCalledWith(expect.any(Function), 1990)
+			expect(setTimeout).toBeCalledWith(expect.any(Function), SESSION_KEEPER_INTERVAL_MS)
 		})
 
 		it('upon reaching timeout an emptyCommand is written on the already ready socket', async () => {

--- a/packages/timeline-state-resolver/src/devices/__tests__/telemetrics.spec.ts
+++ b/packages/timeline-state-resolver/src/devices/__tests__/telemetrics.spec.ts
@@ -93,7 +93,7 @@ describe('telemetrics', () => {
 			expect(setTimeout).toBeCalledWith(expect.any(Function), SESSION_KEEPER_INTERVAL_MS)
 		})
 
-		it('upon reaching timeout an emptyCommand is written on the already ready socket', async () => {
+		it('upon reaching timeout an emptyCommand is written on the already ready socket', () => {
 			jest.useFakeTimers()
 
 			device = createInitializedTelemetricsDevice()

--- a/packages/timeline-state-resolver/src/devices/__tests__/telemetrics.spec.ts
+++ b/packages/timeline-state-resolver/src/devices/__tests__/telemetrics.spec.ts
@@ -10,7 +10,7 @@ import { DoOrderFunctionNothing } from '../doOnTime'
 jest.spyOn(global, 'setTimeout')
 
 const SERVER_PORT = 5000
-const SERVER_HOST = '127.0.0.1'
+const SERVER_HOST = '1.1.1.1'
 const EMPTY_COMMAND_HEX = '0D'
 
 const MOCKED_SOCKET_START_KEEP_ALIVE = jest.fn()

--- a/packages/timeline-state-resolver/src/devices/telemetrics.ts
+++ b/packages/timeline-state-resolver/src/devices/telemetrics.ts
@@ -184,9 +184,9 @@ export class TelemetricsDevice extends DeviceWithState<TelemetricsState, DeviceO
 			return
 		}
 		const emptyCommand: Buffer = Buffer.from(EMPTY_COMMAND_HEX, 'hex')
-		this.socket.write(emptyCommand, (err) => {
-			if (err) {
-				this.updateStatus(StatusCode.BAD, err)
+		this.socket.write(emptyCommand, (error: Error | undefined) => {
+			if (error) {
+				this.updateStatus(StatusCode.BAD, error)
 				this.stopSessionKeeper()
 			}
 			this.startSessionKeeper()

--- a/packages/timeline-state-resolver/src/devices/telemetrics.ts
+++ b/packages/timeline-state-resolver/src/devices/telemetrics.ts
@@ -187,9 +187,9 @@ export class TelemetricsDevice extends DeviceWithState<TelemetricsState, DeviceO
 		this.socket.write(emptyCommand, (error: Error | undefined) => {
 			if (error) {
 				this.updateStatus(StatusCode.BAD, error)
-				this.stopSessionKeeper()
+			} else {
+				this.startSessionKeeper()
 			}
-			this.startSessionKeeper()
 		})
 	}
 

--- a/packages/timeline-state-resolver/src/devices/telemetrics.ts
+++ b/packages/timeline-state-resolver/src/devices/telemetrics.ts
@@ -29,7 +29,7 @@ interface TelemetricsState {
  * This class uses a fire and forget approach.
  */
 export class TelemetricsDevice extends DeviceWithState<TelemetricsState, DeviceOptionsTelemetrics> {
-	private doOnTime: DoOnTime
+	private readonly doOnTime: DoOnTime
 
 	private socket: Socket
 	private statusCode: StatusCode = StatusCode.UNKNOWN

--- a/packages/timeline-state-resolver/src/devices/telemetrics.ts
+++ b/packages/timeline-state-resolver/src/devices/telemetrics.ts
@@ -179,7 +179,7 @@ export class TelemetricsDevice extends DeviceWithState<TelemetricsState, DeviceO
 	}
 
 	private startSessionKeeper(): void {
-		if (!this.sessionKeeperTimer) {
+		if (this.sessionKeeperTimer) {
 			return
 		}
 		this.sessionKeeperTimer = setTimeout(this.keepSessionAlive.bind(this), SESSION_KEEPER_INTERVAL_MS)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduces change in idle TCP socket behaviour for Telemetrics client as device status bug fix.

* **What is the current behavior?** (You can also link to an open issue here)
Telemetrics device closes socket connection after idling more than 2s, causing device to be reported as unavailable and triggers reconnect.


* **What is the new behavior (if this is a feature change)?**
Periodically, an 'empty command' will be written on the opened socket aiming to simulate non-actionable (or keep-alive) activity that prevents socket to be closed due to inactivity. This sequence starts once connected socket is announced ready and restarts by data events or dedicated timer (1990ms).

Since socket is not closed due to keep-alive activity - device will not be reported as unavailable.


* **Other information**:
