### PR TITLE
SOF-2119 Update preview input from aux lookahead

### DIFF
--- a/packages/timeline-state-resolver/package.json
+++ b/packages/timeline-state-resolver/package.json
@@ -59,7 +59,7 @@
 	"dependencies": {
 		"@tv2media/v-connection": "^7.2.1",
 		"atem-connection": "2.4.0",
-		"atem-state": "^0.12.2",
+		"atem-state": "^0.13.0",
 		"casparcg-connection": "^6.0.0",
 		"casparcg-state": "^3.0.1",
 		"debug": "^4.3.1",

--- a/packages/timeline-state-resolver/src/integrations/atem/index.ts
+++ b/packages/timeline-state-resolver/src/integrations/atem/index.ts
@@ -307,12 +307,11 @@ export class AtemDevice extends DeviceWithState<DeviceState, DeviceOptionsAtemIn
 							if (tlObject.content.type === TimelineContentTypeAtem.AUX) {
 								const atemObj = tlObject as any as TimelineObjAtemAUX
 								deviceState.video.auxilliaries[mapping.index] = atemObj.content.aux.input
-								// TODO: Remove again. Test if we can set preview with lookahead for T-bar test.
-								if (mapping.layerName === 'atem_aux_lookahead') {
-									const mixEffect: MixEffect | undefined = deviceState.video.mixEffects[0]
-									if (mixEffect) {
-										mixEffect.previewInput = atemObj.content.aux.input
-									}
+								// TODO: Remove again. Hack to make Atem update its own Next with our input.
+								const tv2LookaheadLayerMappingName = 'atem_aux_lookahead'
+								if (layerName === tv2LookaheadLayerMappingName) {
+									const me: MixEffect = AtemStateUtil.getMixEffect(deviceState, 0)
+									me.previewInput = atemObj.content.aux.input
 								}
 							}
 							break

--- a/yarn.lock
+++ b/yarn.lock
@@ -2300,10 +2300,10 @@ atem-connection@2.4.0:
     tslib "^1.13.0"
     wavefile "^8.4.4"
 
-atem-state@^0.12.2:
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/atem-state/-/atem-state-0.12.2.tgz#40a97b77d32ed9effee5e99505193d1e0c94deca"
-  integrity sha512-4OFp3HHpvhmcBHOpx7M/8Gjpf1xUkH5GZZGdPJGQt3N9JOZggONbC7ndoko4qhwapl7EQkM2eMhkI+uDAKj8LQ==
+atem-state@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/atem-state/-/atem-state-0.13.0.tgz#07f6452364550cc2af0c9ddfdf1ffe40010e81c9"
+  integrity sha512-uEzt15vP8c155OfsyuWrkbxb3PKoLBpy4Q7WAlqx2t4AZTGSbHCpQz8YIx/9Zg9zPw9bDLt8eVUJBp30QYLp8Q==
   dependencies:
     deepmerge "^4.2.2"
     tslib "^2.3.1"


### PR DESCRIPTION
Hack: Update the 'previewInput' on the ME from the aux on the TV2 specific lookahead layer.

In order to update the Preview in Atem, we need to set the `previewInput` on the ME for program. This info is dynamic and not know ahead of time from Sofie, so we need to update the ME when we receive the AUX TimelineObject for our lookahead.
