### PR TITLE
AG-315 Telemetrics now only stops retrying to connect if it has been …

### DIFF
--- a/packages/timeline-state-resolver/.eslintrc.json
+++ b/packages/timeline-state-resolver/.eslintrc.json
@@ -9,7 +9,8 @@
 				"@typescript-eslint/no-non-null-assertion": 0,
 				"@typescript-eslint/ban-types": 0,
 				"@typescript-eslint/ban-ts-comment": 0,
-				"@typescript-eslint/no-namespace": 0
+				"@typescript-eslint/no-namespace": 0,
+				"@typescript-eslint/no-inferrable-types": 0
 			}
 		},
 		{

--- a/packages/timeline-state-resolver/src/devices/__tests__/telemetrics.spec.ts
+++ b/packages/timeline-state-resolver/src/devices/__tests__/telemetrics.spec.ts
@@ -115,16 +115,6 @@ describe('telemetrics', () => {
 			expect(result.statusCode).toBe(StatusCode.BAD)
 		})
 
-		it('on close, closed without error, status is UNKNOWN', () => {
-			device = createTelemetricsDevice()
-
-			void device.init({ host: SERVER_HOST })
-			SOCKET_EVENTS.get('close')!(false)
-
-			const result = device.getStatus()
-			expect(result.statusCode).toBe(StatusCode.UNKNOWN)
-		})
-
 		it('on connect, status is GOOD', () => {
 			device = createTelemetricsDevice()
 

--- a/packages/timeline-state-resolver/src/devices/telemetrics.ts
+++ b/packages/timeline-state-resolver/src/devices/telemetrics.ts
@@ -35,6 +35,7 @@ export class TelemetricsDevice extends DeviceWithState<TelemetricsState, DeviceO
 	private resolveInitPromise: (value: boolean) => void
 
 	private retryConnectionTimer: Timer | undefined
+	private shouldReconnectOnWebSocketClose: boolean = true
 
 	constructor(deviceId: string, deviceOptions: DeviceOptionsTelemetrics, getCurrentTime: () => Promise<number>) {
 		super(deviceId, deviceOptions, getCurrentTime)
@@ -126,6 +127,7 @@ export class TelemetricsDevice extends DeviceWithState<TelemetricsState, DeviceO
 	}
 
 	async init(options: TelemetricsOptions): Promise<boolean> {
+		this.shouldReconnectOnWebSocketClose = true
 		const initPromise = new Promise<boolean>((resolve) => {
 			this.resolveInitPromise = resolve
 		})
@@ -151,9 +153,9 @@ export class TelemetricsDevice extends DeviceWithState<TelemetricsState, DeviceO
 			this.updateStatus(StatusCode.BAD, error)
 		})
 
-		this.socket.on('close', (hadError: boolean) => {
+		this.socket.on('close', () => {
 			this.doOnTime.dispose()
-			if (hadError) {
+			if (this.shouldReconnectOnWebSocketClose) {
 				this.updateStatus(StatusCode.BAD)
 				this.reconnect(host, port)
 			} else {
@@ -194,6 +196,7 @@ export class TelemetricsDevice extends DeviceWithState<TelemetricsState, DeviceO
 	}
 
 	async terminate(): Promise<boolean> {
+		this.shouldReconnectOnWebSocketClose = false
 		this.doOnTime.dispose()
 		if (this.retryConnectionTimer) {
 			clearTimeout(this.retryConnectionTimer)


### PR DESCRIPTION
Disclaimer: I don't know the exact thing that Telemetrics does with a WebSocket on a show reload.

When we would "end" a show in Telemetrics, we would lose our WebSocket connection to the Telemetrics and not try to connect to it again.
Our retry logic would only be started on a WebSocket close event if the close event had had an error. 

Current theory is, that on a "show end" Telemetrics simply closes the socket cleanly. This would not prompt our reconnection logic and the PlayoutGateway would simply not try and reconnect to it.

This PR changes our reconnection logic to always try and reconnect to the Telemetrics on a WebSocket close event unless we have _explicitly_ said that we want to close the WebSocket (this is done by the PlayoutGateway by calling the `terminate()` method).